### PR TITLE
feat: update farms post endpoint to only allow authenticated users (#15)

### DIFF
--- a/src/idempotency/persistence/mod.rs
+++ b/src/idempotency/persistence/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 use actix_web::HttpResponse;
 use deadpool_redis::Pool;
 use sqlx::{PgPool, Postgres, Transaction};
+use uuid::Uuid;
 
 mod error;
 mod postgres;
@@ -18,11 +19,23 @@ mod redis;
 
 pub use error::IdempotencyPersistenceError;
 
+fn build_user_scoped_idempotency_key(
+    redis_key_prefix: &str,
+    user_id: Uuid,
+    idempotency_key: &str,
+) -> Result<IdempotencyKey, IdempotencyError> {
+    IdempotencyKey::try_from(format!(
+        "{}:{}:{}",
+        redis_key_prefix, user_id, idempotency_key
+    ))
+    .map_err(|e| IdempotencyError::UnexpectedError(e.into()))
+}
+
 pub async fn save_response(
     redis_pool: &Pool,
     transaction: Transaction<'static, Postgres>,
     idempotency_key: &str,
-    //user_id: Uuid,
+    user_id: Uuid,
     idempotency_settings: &IdempotencySettings,
     http_response: HttpResponse,
 ) -> Result<(HttpResponse, Transaction<'static, Postgres>), IdempotencyError> {
@@ -31,13 +44,11 @@ pub async fn save_response(
         // No idempotency just return the provided response
         IdempotencyEngine::None => Ok((idempotency_data.into_response()?, transaction)),
         IdempotencyEngine::Redis => {
-            let idempotency_key = IdempotencyKey::try_from(format!(
-                "{}:{}", // Add an extra ':{}' when user_id is available
-                idempotency_settings.redis_key_prefix,
-                //user_id.to_string(),
-                idempotency_key
-            ))
-            .map_err(|e| IdempotencyError::UnexpectedError(e.into()))?;
+            let idempotency_key = build_user_scoped_idempotency_key(
+                &idempotency_settings.redis_key_prefix,
+                user_id,
+                idempotency_key,
+            )?;
             redis::save_response(
                 redis_pool,
                 &idempotency_key,
@@ -73,7 +84,7 @@ pub async fn try_processing(
     redis_pool: &Pool,
     db_pool: &PgPool,
     idempotency_key: &str,
-    //user_id: Uuid,
+    user_id: Uuid,
     idempotency_settings: &IdempotencySettings,
 ) -> Result<IdempotencyNextAction, IdempotencyError> {
     let transaction = db_pool
@@ -84,13 +95,11 @@ pub async fn try_processing(
     match idempotency_settings.engine {
         IdempotencyEngine::None => Ok(IdempotencyNextAction::StartProcessing(transaction)),
         IdempotencyEngine::Redis => {
-            let idempotency_key = IdempotencyKey::try_from(format!(
-                "{}:{}", // Add an extra ':{}' when user_id is available
-                idempotency_settings.redis_key_prefix,
-                //user_id.to_string(),
-                idempotency_key
-            ))
-            .map_err(|e| IdempotencyError::UnexpectedError(e.into()))?;
+            let idempotency_key = build_user_scoped_idempotency_key(
+                &idempotency_settings.redis_key_prefix,
+                user_id,
+                idempotency_key,
+            )?;
 
             match redis::try_processing(redis_pool, &idempotency_key, idempotency_settings)
                 .await

--- a/src/routes/farms/post.rs
+++ b/src/routes/farms/post.rs
@@ -1,4 +1,5 @@
 use crate::{
+    authentication::CurrentUser,
     configuration::Settings,
     domain::farm::{Address, Canton, Categories, Name, Point},
     idempotency::{IdempotencyError, IdempotencyNextAction, save_response, try_processing},
@@ -27,6 +28,7 @@ pub struct FormData {
     skip(body, pool, redis_pool, configuration)
 )]
 pub async fn create(
+    current_user: CurrentUser,
     body: web::Json<FormData>,
     pool: web::Data<PgPool>,
     redis_pool: web::Data<Pool>,
@@ -67,6 +69,7 @@ pub async fn create(
         &redis_pool,
         &pool,
         body.idempotency_key.as_str(),
+        current_user.id,
         &configuration.idempotency,
     )
     .await
@@ -95,6 +98,7 @@ pub async fn create(
         &redis_pool,
         transaction,
         body.idempotency_key.as_str(),
+        current_user.id,
         &configuration.idempotency,
         response,
     )

--- a/tests/api/farms.rs
+++ b/tests/api/farms.rs
@@ -1,4 +1,4 @@
-use crate::helpers::{TestApp, redis_exists_with_retry, spawn_app};
+use crate::helpers::{TestApp, TestUser, redis_exists_with_retry, spawn_app};
 use actix_web::http::StatusCode;
 use chrono::Utc;
 use deadpool_redis::redis::AsyncCommands;
@@ -116,6 +116,19 @@ async fn create_n_farms(app: &TestApp, n: usize) -> Vec<Farm> {
     farms
 }
 
+async fn log_in_test_user(app: &TestApp, user: &TestUser) {
+    user.store(&app.db_pool).await;
+
+    let response = app
+        .post_login(&serde_json::json!({
+            "email": user.email,
+            "password": user.password
+        }))
+        .await;
+
+    assert_eq!(StatusCode::OK.as_u16(), response.status().as_u16());
+}
+
 #[tokio::test]
 async fn get_farms_returns_empty_list_when_no_farms_exist() {
     // Arrange
@@ -206,6 +219,10 @@ async fn create_farm_returns_a_200_for_valid_body_data() {
     let farm = generate_farm();
     let idempotency_key = Uuid::new_v4();
 
+    // Log in user
+    let user = TestUser::generate_user();
+    log_in_test_user(&app, &user).await;
+
     // Act
     let body = farm_to_json(&farm, idempotency_key);
 
@@ -232,11 +249,31 @@ async fn create_farm_returns_a_200_for_valid_body_data() {
 }
 
 #[tokio::test]
+async fn create_farm_returns_201_for_authenticated_admins() {
+    let app = spawn_app().await;
+    let user = TestUser::generate_admin();
+    log_in_test_user(&app, &user).await;
+
+    let farm = generate_farm();
+    let idempotency_key = Uuid::new_v4();
+    let body = farm_to_json(&farm, idempotency_key);
+
+    let response = app.post_farm(&body).await;
+
+    assert_eq!(StatusCode::CREATED.as_u16(), response.status().as_u16());
+}
+
+#[tokio::test]
 async fn create_farm_returns_a_500_when_unexpected_error_occurs() {
     // Arrange
     let app = spawn_app().await;
     let farm = generate_farm();
     let idempotency_key = Uuid::new_v4();
+
+    // Log in user
+    let user = TestUser::generate_user();
+    log_in_test_user(&app, &user).await;
+
     // Break the DB
     break_farms_table(&app).await;
 
@@ -247,6 +284,22 @@ async fn create_farm_returns_a_500_when_unexpected_error_occurs() {
     // Assert
     assert_eq!(
         StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+        response.status().as_u16()
+    );
+}
+
+#[tokio::test]
+async fn create_farm_returns_401_for_unauthenticated_users() {
+    let app = spawn_app().await;
+    let farm = generate_farm();
+    let idempotency_key = Uuid::new_v4();
+
+    let body = farm_to_json(&farm, idempotency_key);
+
+    let response = app.post_farm(&body).await;
+
+    assert_eq!(
+        StatusCode::UNAUTHORIZED.as_u16(),
         response.status().as_u16()
     );
 }
@@ -338,6 +391,10 @@ async fn create_farm_returns_a_400_for_invalid_body_data() {
         ),
     ];
 
+    // Log in user
+    let user = TestUser::generate_user();
+    log_in_test_user(&app, &user).await;
+
     for (invalid_body, error_message) in test_cases {
         // Act
         let response = app.post_farm(&invalid_body).await;
@@ -393,6 +450,10 @@ async fn create_farm_returns_400_for_invalid_coordinate_format() {
         ),
     ];
 
+    // Log in user
+    let user = TestUser::generate_user();
+    log_in_test_user(&app, &user).await;
+
     for (invalid_body, error_message) in test_cases {
         // Act
         let response = app.post_farm(&invalid_body).await;
@@ -411,6 +472,10 @@ async fn create_farm_returns_400_for_invalid_coordinate_format() {
 async fn create_farm_returns_400_for_coordinates_outside_switzerland() {
     // Arrange
     let app = spawn_app().await;
+
+    // Log in user
+    let user = TestUser::generate_user();
+    log_in_test_user(&app, &user).await;
 
     let body = serde_json::json!({
         "name": "Berlin Farm",
@@ -433,6 +498,10 @@ async fn create_farm_returns_400_for_invalid_latitude() {
     // Arrange
     let app = spawn_app().await;
 
+    // Log in user
+    let user = TestUser::generate_user();
+    log_in_test_user(&app, &user).await;
+
     let body = serde_json::json!({
         "name": "Test Farm",
         "address": "Test Address",
@@ -453,6 +522,10 @@ async fn create_farm_returns_400_for_invalid_latitude() {
 async fn create_farm_returns_400_for_invalid_longitude() {
     // Arrange
     let app = spawn_app().await;
+
+    // Log in user
+    let user = TestUser::generate_user();
+    log_in_test_user(&app, &user).await;
 
     let body = serde_json::json!({
         "name": "Test Farm",
@@ -479,6 +552,10 @@ async fn create_farm_returns_200_for_all_valid_swiss_cantons() {
         "ZH", "BE", "LU", "UR", "SZ", "OW", "NW", "GL", "ZG", "FR", "SO", "BS", "BL", "SH", "AR",
         "AI", "SG", "GR", "AG", "TG", "TI", "VD", "VS", "NE", "GE", "JU",
     ];
+
+    // Log in user
+    let user = TestUser::generate_user();
+    log_in_test_user(&app, &user).await;
 
     for canton in cantons {
         let body = serde_json::json!({
@@ -510,6 +587,10 @@ async fn create_farm_called_multiple_times_sequentially_doesnt_create_duplicate_
     let farm = generate_farm();
     let idempotency_key = Uuid::new_v4();
 
+    // Log in user
+    let user = TestUser::generate_user();
+    log_in_test_user(&app, &user).await;
+
     // Act
     let body = farm_to_json(&farm, idempotency_key);
 
@@ -534,6 +615,10 @@ async fn create_farm_called_multiple_times_in_parallel_doesnt_create_duplicate_f
     let app = spawn_app().await;
     let farm = generate_farm();
     let idempotency_key = Uuid::new_v4();
+
+    // Log in user
+    let user = TestUser::generate_user();
+    log_in_test_user(&app, &user).await;
 
     // Act
     let body = farm_to_json(&farm, idempotency_key);
@@ -570,6 +655,10 @@ async fn create_farm_creates_redis_key_with_response() {
     let farm = generate_farm();
     let idempotency_key = Uuid::new_v4();
 
+    // Log in user
+    let user = TestUser::generate_user();
+    log_in_test_user(&app, &user).await;
+
     // Act
     let body = farm_to_json(&farm, idempotency_key);
 
@@ -579,8 +668,8 @@ async fn create_farm_creates_redis_key_with_response() {
     assert_eq!(StatusCode::CREATED.as_u16(), response.status().as_u16());
 
     let idempotency_key = IdempotencyKey::try_from(format!(
-        "{}:{}",
-        app.configuration.idempotency.redis_key_prefix, idempotency_key
+        "{}:{}:{}",
+        app.configuration.idempotency.redis_key_prefix, user.id, idempotency_key
     ))
     .expect("Failed to parse idempotency key");
     let mut redis_connection = app


### PR DESCRIPTION
### **This PR restricts POST /farms to authenticated users.**

It updates the create-farm flow to require a valid session-backed CurrentUser, so only logged-in users can create farms. Both `USER` and `ADMIN` roles are allowed; the change is authentication-only and does not introduce role-based authorisation yet.

It also scopes idempotency per authenticated user by including the user ID in the Redis idempotency key. This prevents different users from colliding if they happen to reuse the same idempotency key.

### **Included**
- Authentication requirement for POST /farms
- User-scoped idempotency keys for farm creation
- API tests covering:
- Unauthenticated POST /farms returns 401
- Authenticated USER can create farms
- Authenticated ADMIN can create farms
- Updated Redis idempotency key behaviour

### **Out of scope**
- Role-based authorisation for farm creation
- Restricting farm creation to admins only
- Broader protection of other endpoints beyond this route