### PR TITLE
feat: add endpoint to fetch a farm by ID (#11)

### DIFF
--- a/.sqlx/query-1f2a47a6b88bdce7ee4304654cdbbde5be919eec9b4aa191eb131fd9d52ca3bf.json
+++ b/.sqlx/query-1f2a47a6b88bdce7ee4304654cdbbde5be919eec9b4aa191eb131fd9d52ca3bf.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id,\n            name as \"name: Name\",\n            address as \"address: Address\",\n            canton as \"canton: Canton\",\n            coordinates as \"coordinates: Point\",\n            categories as \"categories: Categories\",\n            created_at,\n            updated_at\n        FROM farms\n        WHERE id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name: Name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "address: Address",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "canton: Canton",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "coordinates: Point",
+        "type_info": "Point"
+      },
+      {
+        "ordinal": 5,
+        "name": "categories: Categories",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "1f2a47a6b88bdce7ee4304654cdbbde5be919eec9b4aa191eb131fd9d52ca3bf"
+}

--- a/api_docs/Get Farm.bru
+++ b/api_docs/Get Farm.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Farm
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{URL}}/farms/{{id}}
+  body: none
+  auth: inherit
+}
+
+vars:pre-request {
+  id: 9b67e2ef-2c4b-49c2-92d7-b2a3d88d2b61
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/src/routes/farms/error.rs
+++ b/src/routes/farms/error.rs
@@ -13,6 +13,8 @@ pub enum FarmError {
     // this field is also used as error `source`. this denotes what should be returned as root cause
     #[error(transparent)]
     DuplicateRequestConflict(#[from] IdempotencyError),
+    #[error("Farm not found.")]
+    NotFound,
 }
 impl ResponseError for FarmError {
     fn status_code(&self) -> StatusCode {
@@ -20,6 +22,7 @@ impl ResponseError for FarmError {
             Self::ValidationError(_) => StatusCode::BAD_REQUEST,
             Self::UnexpectedError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Self::DuplicateRequestConflict(_) => StatusCode::CONFLICT,
+            Self::NotFound => StatusCode::NOT_FOUND,
         }
     }
 }

--- a/src/routes/farms/get.rs
+++ b/src/routes/farms/get.rs
@@ -5,6 +5,12 @@ use crate::{
 use actix_web::{HttpResponse, web};
 use anyhow::Context;
 use sqlx::PgPool;
+use uuid::Uuid;
+
+#[derive(serde::Deserialize)]
+pub struct FarmPath {
+    id: String,
+}
 
 pub async fn get_all(pool: web::Data<PgPool>) -> Result<HttpResponse, FarmError> {
     let farms = get_farms(&pool).await?;
@@ -37,4 +43,44 @@ pub async fn get_farms(pool: &PgPool) -> Result<Vec<Farm>, FarmError> {
     //  and enriches it with additional context around the intentions of the caller/
 
     Ok(farms)
+}
+
+pub async fn get_by_id(
+    path: web::Path<FarmPath>,
+    pool: web::Data<PgPool>,
+) -> Result<HttpResponse, FarmError> {
+    let farm_id = Uuid::parse_str(&path.id)
+        .map_err(|_| FarmError::ValidationError("Invalid farm id.".to_string()))?;
+
+    let farm = get_farm_by_id(farm_id, &pool).await?;
+
+    match farm {
+        Some(farm) => Ok(HttpResponse::Ok().json(farm)),
+        None => Err(FarmError::NotFound),
+    }
+}
+
+pub async fn get_farm_by_id(farm_id: Uuid, pool: &PgPool) -> Result<Option<Farm>, FarmError> {
+    let farm = sqlx::query_as!(
+        Farm,
+        r#"
+        SELECT
+            id,
+            name as "name: Name",
+            address as "address: Address",
+            canton as "canton: Canton",
+            coordinates as "coordinates: Point",
+            categories as "categories: Categories",
+            created_at,
+            updated_at
+        FROM farms
+        WHERE id = $1
+        "#,
+        farm_id
+    )
+    .fetch_optional(pool)
+    .await
+    .context("Failed to fetch farm from the database.")?;
+
+    Ok(farm)
 }

--- a/src/routes/farms/mod.rs
+++ b/src/routes/farms/mod.rs
@@ -7,7 +7,7 @@ mod get;
 mod post;
 
 pub use error::FarmError;
-pub use get::get_all;
+pub use get::{get_all, get_by_id};
 pub use post::create;
 
 #[derive(serde::Deserialize, serde::Serialize, sqlx::FromRow)]

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -167,6 +167,7 @@ pub async fn run(
             .route("/health_check", web::get().to(health_check))
             .route("/farms", web::post().to(farms::create))
             .route("/farms", web::get().to(farms::get_all))
+            .route("/farms/{id}", web::get().to(farms::get_by_id))
             .route("/login", web::post().to(authentication::log_in))
             .route("/logout", web::post().to(authentication::log_out))
             .route("/me", web::get().to(authentication::get_me))

--- a/tests/api/farms.rs
+++ b/tests/api/farms.rs
@@ -213,6 +213,68 @@ async fn get_farms_returns_500_when_unexpected_error_occurs() {
 }
 
 #[tokio::test]
+async fn get_farm_returns_200_and_the_request_farm_when_it_exists() {
+    let app = spawn_app().await;
+
+    let requested_farm = create_single_farm(&app).await;
+    let other_farm = create_single_farm(&app).await;
+
+    let response = app.get_farm(requested_farm.id).await;
+
+    assert_eq!(StatusCode::OK.as_u16(), response.status().as_u16());
+
+    let farm: Farm = response
+        .json()
+        .await
+        .expect("Failed to parse response as JSON.");
+
+    assert_eq!(farm.id, requested_farm.id);
+    assert_eq!(farm.name, requested_farm.name);
+    assert_eq!(farm.address, requested_farm.address);
+    assert_eq!(farm.canton, requested_farm.canton);
+    assert_eq!(farm.coordinates, requested_farm.coordinates);
+    assert_eq!(farm.categories, requested_farm.categories);
+
+    assert_ne!(farm.id, other_farm.id);
+}
+
+#[tokio::test]
+async fn get_farm_returns_404_when_farm_does_not_exist() {
+    let app = spawn_app().await;
+
+    let missing_farm_id = Uuid::new_v4();
+
+    let response = app.get_farm(missing_farm_id).await;
+
+    assert_eq!(StatusCode::NOT_FOUND.as_u16(), response.status().as_u16());
+}
+
+#[tokio::test]
+async fn get_farm_returns_400_when_farm_id_is_not_an_uuid() {
+    let app = spawn_app().await;
+
+    let response = app.get_farm_by_raw_id("not-a-valid-uuid").await;
+
+    assert_eq!(StatusCode::BAD_REQUEST.as_u16(), response.status().as_u16());
+}
+
+#[tokio::test]
+async fn get_farm_returns_500_when_unexpected_error_occurs() {
+    let app = spawn_app().await;
+
+    let farm_id = Uuid::new_v4();
+
+    break_farms_table(&app).await;
+
+    let response = app.get_farm(farm_id).await;
+
+    assert_eq!(
+        StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+        response.status().as_u16()
+    );
+}
+
+#[tokio::test]
 async fn create_farm_returns_a_200_for_valid_body_data() {
     // Arrange
     let app = spawn_app().await;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -127,6 +127,20 @@ impl TestApp {
     }
 
     #[allow(dead_code)]
+    pub async fn get_farm(&self, farm_id: Uuid) -> reqwest::Response {
+        self.get_farm_by_raw_id(&farm_id.to_string()).await
+    }
+
+    #[allow(dead_code)]
+    pub async fn get_farm_by_raw_id(&self, farm_id: &str) -> reqwest::Response {
+        self.api_client
+            .get(format!("{}/farms/{}", self.address, farm_id))
+            .send()
+            .await
+            .expect("Failed to execute request.")
+    }
+
+    #[allow(dead_code)]
     pub async fn post_farm(&self, body: &serde_json::Value) -> reqwest::Response {
         self.api_client
             .post(format!("{}/farms", &self.address))


### PR DESCRIPTION
## Overview
- Add `GET /farms/{id}` to fetch a single farm by UUID
- Return `404 Not Found` when the farm does not exist
- Return `400 Bad Request` for invalid UUID path parameters

## Documentation
- Add a Bruno request for manual endpoint testing