### PR TITLE
feat: user registration now uses `username`

### DIFF
--- a/.sqlx/query-59bca22c22ff5b78e4b77f5254b631ba29b642445974fb40d8bbaf83eeebc1ed.json
+++ b/.sqlx/query-59bca22c22ff5b78e4b77f5254b631ba29b642445974fb40d8bbaf83eeebc1ed.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT username FROM users WHERE email = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "username",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "59bca22c22ff5b78e4b77f5254b631ba29b642445974fb40d8bbaf83eeebc1ed"
+}

--- a/README.md
+++ b/README.md
@@ -162,11 +162,14 @@ The service currently exposes:
 
 Registration is public and email-verified:
 
-1. `POST /register` with `{ "email", "password" }` creates a `USER` account in a
-   `PENDING_VERIFICATION` state and emails a verification link. It always
+1. `POST /register` with `{ "username", "email", "password" }` creates a `USER`
+   account in a `PENDING_VERIFICATION` state and emails a verification link. It
    responds `202 Accepted` - the same response for new and already-registered
-   emails - so it cannot be used to enumerate accounts. Passwords must be at
-   least 12 characters; `role` is server-owned and cannot be set by the client.
+   emails - so it cannot be used to enumerate accounts. A taken **username**,
+   however, returns `409 Conflict`: usernames are public identifiers, so a clash
+   is reported rather than hidden. Usernames are 3-30 characters
+   (letters/digits/`_`/`-`, stored lowercased); passwords must be at least 12
+   characters; `role` is server-owned and cannot be set by the client.
 2. `POST /verify-email` with `{ "token" }` consumes the (single-use, expiring)
    token, marks the account `ACTIVE`, and sets `email_verified_at`.
 3. `POST /login` validates credentials and, on success, persists a

--- a/api_docs/Register.bru
+++ b/api_docs/Register.bru
@@ -16,6 +16,7 @@ headers {
 
 body:json {
   {
+    "username": "new-user",
     "email": "new.user@example.com",
     "password": "a-long-enough-password"
   }
@@ -27,11 +28,18 @@ docs {
   Creates a USER account in the `PENDING_VERIFICATION` state and emails a
   verification link. The user cannot log in until they verify their email.
 
+  The username is chosen by the user: 3-30 characters, letters/digits/`_`/`-`,
+  starting with a letter or digit. It is stored lowercased (case-insensitive
+  uniqueness).
+
   Responses:
   - 202 Accepted: request accepted. Returned for both new and already-registered
     emails - the response is intentionally generic so it cannot be used to probe
     which emails exist.
-  - 400 Bad Request: invalid email or a password shorter than 12 characters.
+  - 400 Bad Request: invalid username, invalid email, or a password shorter than
+    12 characters.
+  - 409 Conflict: the username is already taken. Unlike email, a username is a
+    public identifier, so a clash is reported rather than hidden.
   - 429 Too Many Requests: rate limit exceeded (per IP and per email).
 
   The `role` is server-owned and cannot be set from the request body.

--- a/src/authentication/registration.rs
+++ b/src/authentication/registration.rs
@@ -1,6 +1,6 @@
 use crate::authentication::password::compute_password_hash;
 use crate::configuration::RegistrationSettings;
-use crate::domain::user::{Email, Role, UserPassword, UserStatus};
+use crate::domain::user::{Email, Role, UserPassword, UserStatus, Username};
 use crate::email_client::EmailClient;
 use crate::errors::error_chain_fmt;
 use crate::telemetry::spawn_blocking_with_tracing;
@@ -18,6 +18,8 @@ use uuid::Uuid;
 pub enum RegisterUserError {
     #[error(transparent)]
     UnexpectedError(#[from] anyhow::Error),
+    #[error("Username is already taken.")]
+    UsernameTaken,
     #[error("Failed to deliver the verification email.")]
     EmailDeliveryError(#[source] anyhow::Error),
 }
@@ -30,9 +32,10 @@ impl Debug for RegisterUserError {
 
 #[tracing::instrument(
     name = "Register a new user",
-    skip(email, password, pool, email_client, settings)
+    skip(username, email, password, pool, email_client, settings)
 )]
 pub async fn register_user(
+    username: Username,
     email: Email,
     password: UserPassword,
     pool: &PgPool,
@@ -58,17 +61,23 @@ pub async fn register_user(
         return Ok(());
     }
 
-    let user_id = match insert_pending_user(&mut transaction, &email, password_hash).await {
-        Ok(user_id) => user_id,
-        // Lost a race with a concurrent registration for the same email:
-        // the unique constraint on email fired. Same generic success.
-        Err(e) if is_unique_violation(&e) => return Ok(()),
-        Err(e) => {
-            return Err(anyhow::Error::from(e)
-                .context("Failed to insert new user.")
-                .into());
-        }
-    };
+    let user_id =
+        match insert_pending_user(&mut transaction, &username, &email, password_hash).await {
+            Ok(user_id) => user_id,
+            Err(e) => match unique_violation_constraint(&e).as_deref() {
+                // A username is a public identifier, so it is fine - and better UX -
+                // to tell the caller it is already taken.
+                Some("users_username_key") => return Err(RegisterUserError::UsernameTaken),
+                // Any other unique violation is the email constraint racing the check
+                // above. Stay generic so email existence is never revealed.
+                Some(_) => return Ok(()),
+                None => {
+                    return Err(anyhow::Error::from(e)
+                        .context("Failed to insert new user.")
+                        .into());
+                }
+            },
+        };
 
     let token = generate_verification_token();
     store_verification_token(&mut transaction, user_id, &token, settings).await?;
@@ -101,10 +110,16 @@ pub fn hash_verification_token(token: &str) -> String {
     hex::encode(Sha256::digest(token.as_bytes()))
 }
 
-fn is_unique_violation(e: &sqlx::Error) -> bool {
-    e.as_database_error()
-        .map(|db_err| db_err.is_unique_violation())
-        .unwrap_or(false)
+/// If `e` is a UNIQUE violation, returns the name of the violated constraint
+/// (Postgres names inline constraints `<table>_<column>_key`). This lets
+/// registration distinguish a username clash (public, surfaced as 409) from an
+/// email clash (private, hidden behind a generic 202).
+fn unique_violation_constraint(e: &sqlx::Error) -> Option<String> {
+    let db_err = e.as_database_error()?;
+    if !db_err.is_unique_violation() {
+        return None;
+    }
+    Some(db_err.constraint().unwrap_or_default().to_string())
 }
 
 #[tracing::instrument(name = "Check whether email is registered", skip_all)]
@@ -123,6 +138,7 @@ async fn email_is_registered(
 #[tracing::instrument(name = "Insert pending user", skip_all)]
 async fn insert_pending_user(
     transaction: &mut Transaction<'_, Postgres>,
+    username: &Username,
     email: &Email,
     password_hash: SecretString,
 ) -> Result<Uuid, sqlx::Error> {
@@ -134,8 +150,7 @@ async fn insert_pending_user(
         VALUES ($1, $2, $3, $4, $5::user_role, $6::user_status, $7)
         "#,
         user_id,
-        // Server-generated username: no public availability checks needed yet.
-        format!("user-{user_id}"),
+        username.as_str(),
         email.as_str(),
         password_hash.expose_secret(),
         Role::User as Role,

--- a/src/domain/user/mod.rs
+++ b/src/domain/user/mod.rs
@@ -2,8 +2,10 @@ mod email;
 mod password;
 mod role;
 mod status;
+mod username;
 
 pub use email::{Email, EmailError};
 pub use password::{UserPassword, UserPasswordError};
 pub use role::Role;
 pub use status::UserStatus;
+pub use username::{Username, UsernameError};

--- a/src/domain/user/username.rs
+++ b/src/domain/user/username.rs
@@ -1,0 +1,148 @@
+//! User-chosen username with validation and normalisation.
+
+use std::fmt::Display;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Username(String);
+
+#[derive(Debug, Error)]
+pub enum UsernameError {
+    #[error("Username must be at least 3 characters long.")]
+    TooShort,
+    #[error("Username must be at most 30 characters long.")]
+    TooLong,
+    #[error(
+        "Username may only contain letters, digits, underscores and hyphens, \
+         and must start with a letter or digit."
+    )]
+    InvalidCharacters,
+    #[error("That username is reserved.")]
+    Reserved,
+}
+
+/// Usernames that must not be claimable by ordinary users (impersonation of
+/// system/staff accounts, routing collisions, etc.).
+const RESERVED: &[&str] = &[
+    "admin",
+    "administrator",
+    "root",
+    "support",
+    "help",
+    "system",
+    "farms",
+    "api",
+    "moderator",
+    "mod",
+    "null",
+    "undefined",
+];
+
+impl Username {
+    /// Parse and normalise a user-chosen username.
+    ///
+    /// Rules: 3-30 characters; ASCII letters, digits, `_` or `-`; must start
+    /// with a letter or digit. The value is lowercased so uniqueness is
+    /// case-insensitive and a single canonical column suffices (mirroring how
+    /// `Email` is stored).
+    pub fn parse(s: String) -> Result<Self, UsernameError> {
+        let trimmed = s.trim();
+        let char_count = trimmed.chars().count();
+
+        if char_count < 3 {
+            return Err(UsernameError::TooShort);
+        }
+        if char_count > 30 {
+            return Err(UsernameError::TooLong);
+        }
+
+        let first = trimmed.chars().next().expect("length checked above");
+        if !first.is_ascii_alphanumeric() {
+            return Err(UsernameError::InvalidCharacters);
+        }
+        if !trimmed
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        {
+            return Err(UsernameError::InvalidCharacters);
+        }
+
+        let normalised = trimmed.to_lowercase();
+        if RESERVED.contains(&normalised.as_str()) {
+            return Err(UsernameError::Reserved);
+        }
+
+        Ok(Self(normalised))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl AsRef<str> for Username {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Display for Username {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claims::{assert_err, assert_ok};
+
+    #[test]
+    fn a_valid_username_is_accepted() {
+        assert_ok!(Username::parse("pedro_g".to_string()));
+        assert_ok!(Username::parse("farm-hand-7".to_string()));
+        assert_ok!(Username::parse("abc".to_string()));
+    }
+
+    #[test]
+    fn username_is_lowercased() {
+        let username = Username::parse("PedroG".to_string()).unwrap();
+        assert_eq!("pedrog", username.as_str());
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_trimmed() {
+        let username = Username::parse("  pedro  ".to_string()).unwrap();
+        assert_eq!("pedro", username.as_str());
+    }
+
+    #[test]
+    fn too_short_is_rejected() {
+        assert_err!(Username::parse("ab".to_string()));
+    }
+
+    #[test]
+    fn too_long_is_rejected() {
+        assert_err!(Username::parse("a".repeat(31)));
+    }
+
+    #[test]
+    fn invalid_characters_are_rejected() {
+        assert_err!(Username::parse("bad name".to_string()));
+        assert_err!(Username::parse("user@host".to_string()));
+        assert_err!(Username::parse("emoji\u{1F600}".to_string()));
+    }
+
+    #[test]
+    fn must_start_with_a_letter_or_digit() {
+        assert_err!(Username::parse("-leading".to_string()));
+        assert_err!(Username::parse("_leading".to_string()));
+    }
+
+    #[test]
+    fn reserved_usernames_are_rejected_case_insensitively() {
+        assert_err!(Username::parse("admin".to_string()));
+        assert_err!(Username::parse("ADMIN".to_string()));
+        assert_err!(Username::parse("Root".to_string()));
+    }
+}

--- a/src/routes/authentication/error.rs
+++ b/src/routes/authentication/error.rs
@@ -24,6 +24,8 @@ pub enum VerifyEmailError {
 pub enum RegisterError {
     #[error("{0}")]
     ValidationError(String),
+    #[error("Username is already taken.")]
+    UsernameTaken,
     #[error("Too many registration attempts. Try again later.")]
     RateLimited,
     #[error(transparent)]
@@ -58,6 +60,7 @@ impl ResponseError for RegisterError {
     fn status_code(&self) -> StatusCode {
         match self {
             Self::ValidationError(_) => StatusCode::BAD_REQUEST,
+            Self::UsernameTaken => StatusCode::CONFLICT,
             Self::RateLimited => StatusCode::TOO_MANY_REQUESTS,
             Self::UnexpectedError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }

--- a/src/routes/authentication/register.rs
+++ b/src/routes/authentication/register.rs
@@ -1,6 +1,6 @@
 use crate::authentication::{RegisterUserError, register_user};
 use crate::configuration::Settings;
-use crate::domain::user::{Email, UserPassword};
+use crate::domain::user::{Email, UserPassword, Username};
 use crate::email_client::EmailClient;
 use crate::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::routes::authentication::error::RegisterError;
@@ -11,6 +11,7 @@ use sqlx::PgPool;
 
 #[derive(serde::Deserialize)]
 pub struct RegisterRequest {
+    username: String,
     email: String,
     password: SecretString,
 }
@@ -29,6 +30,8 @@ pub async fn register(
 ) -> Result<HttpResponse, RegisterError> {
     let body = body.into_inner();
 
+    let username = Username::parse(body.username)
+        .map_err(|e| RegisterError::ValidationError(e.to_string()))?;
     let email =
         Email::parse(body.email).map_err(|e| RegisterError::ValidationError(e.to_string()))?;
     let password = UserPassword::parse(body.password)
@@ -37,6 +40,7 @@ pub async fn register(
     enforce_rate_limits(&request, &email, &redis_pool, &configuration).await?;
 
     match register_user(
+        username,
         email,
         password,
         pool.get_ref(),
@@ -46,6 +50,8 @@ pub async fn register(
     .await
     {
         Ok(()) => {}
+        // A username is public, so a clash is reported rather than hidden.
+        Err(RegisterUserError::UsernameTaken) => return Err(RegisterError::UsernameTaken),
         // The account exists; only the email could not be delivered. We still
         // return the generic success below so the caller cannot tell whether
         // the address was new. The user stays pending and can request a resend.

--- a/tests/api/registration.rs
+++ b/tests/api/registration.rs
@@ -13,6 +13,11 @@ fn unique_email() -> String {
     format!("user-{}@example.com", Uuid::new_v4())
 }
 
+/// A unique, valid username (lowercase, <= 30 chars).
+fn unique_username() -> String {
+    format!("u{}", &Uuid::new_v4().simple().to_string()[..12])
+}
+
 /// Accept any number of outbound emails with a 200 response.
 async fn mount_email_ok(app: &TestApp) {
     Mock::given(method("POST"))
@@ -29,6 +34,7 @@ async fn register_returns_202_for_valid_input() {
 
     let response = app
         .post_register(&serde_json::json!({
+            "username": unique_username(),
             "email": unique_email(),
             "password": VALID_PASSWORD,
         }))
@@ -42,10 +48,20 @@ async fn register_returns_202_for_existing_email() {
     let app = spawn_app(IdempotencyEngine::None).await;
     mount_email_ok(&app).await;
     let email = unique_email();
-    let body = serde_json::json!({ "email": email, "password": VALID_PASSWORD });
 
-    let first = app.post_register(&body).await;
-    let second = app.post_register(&body).await;
+    // Same email twice, but a different username each time (an email probe would
+    // use a fresh username), so the email-existence path - not a username clash -
+    // is what is being exercised.
+    let first = app
+        .post_register(&serde_json::json!({
+            "username": unique_username(), "email": email, "password": VALID_PASSWORD,
+        }))
+        .await;
+    let second = app
+        .post_register(&serde_json::json!({
+            "username": unique_username(), "email": email, "password": VALID_PASSWORD,
+        }))
+        .await;
 
     assert_eq!(StatusCode::ACCEPTED.as_u16(), first.status().as_u16());
     // Duplicate registration is indistinguishable from the first.
@@ -64,11 +80,49 @@ async fn register_returns_202_for_existing_email() {
 }
 
 #[tokio::test]
+async fn register_returns_409_for_taken_username() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    mount_email_ok(&app).await;
+    let username = unique_username();
+
+    let first = app
+        .post_register(&serde_json::json!({
+            "username": username, "email": unique_email(), "password": VALID_PASSWORD,
+        }))
+        .await;
+    assert_eq!(StatusCode::ACCEPTED.as_u16(), first.status().as_u16());
+
+    // Same username, different email: the username clash is surfaced (public id).
+    let second = app
+        .post_register(&serde_json::json!({
+            "username": username, "email": unique_email(), "password": VALID_PASSWORD,
+        }))
+        .await;
+    assert_eq!(StatusCode::CONFLICT.as_u16(), second.status().as_u16());
+}
+
+#[tokio::test]
+async fn register_returns_400_for_invalid_username() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+
+    let response = app
+        .post_register(&serde_json::json!({
+            "username": "ab", // too short
+            "email": unique_email(),
+            "password": VALID_PASSWORD,
+        }))
+        .await;
+
+    assert_eq!(StatusCode::BAD_REQUEST.as_u16(), response.status().as_u16());
+}
+
+#[tokio::test]
 async fn register_returns_400_for_invalid_email() {
     let app = spawn_app(IdempotencyEngine::None).await;
 
     let response = app
         .post_register(&serde_json::json!({
+            "username": unique_username(),
             "email": "not-an-email",
             "password": VALID_PASSWORD,
         }))
@@ -83,6 +137,7 @@ async fn register_returns_400_for_short_password() {
 
     let response = app
         .post_register(&serde_json::json!({
+            "username": unique_username(),
             "email": unique_email(),
             "password": "short", // < 12 chars
         }))
@@ -92,13 +147,15 @@ async fn register_returns_400_for_short_password() {
 }
 
 #[tokio::test]
-async fn register_stores_pending_user_with_hashed_password() {
+async fn register_stores_pending_user_with_chosen_username_and_hashed_password() {
     let app = spawn_app(IdempotencyEngine::None).await;
     mount_email_ok(&app).await;
-    // Mixed case to exercise normalisation.
+    // Mixed case to exercise normalisation of both fields.
+    let username = "Pedro_G".to_string();
     let email = format!("User-{}@Example.COM", Uuid::new_v4());
 
     app.post_register(&serde_json::json!({
+        "username": username,
         "email": email,
         "password": VALID_PASSWORD,
     }))
@@ -114,6 +171,17 @@ async fn register_stores_pending_user_with_hashed_password() {
         stored.password_hash
     );
     assert_ne!(VALID_PASSWORD, stored.password_hash);
+
+    // The chosen username is stored, lowercased.
+    let stored_username = sqlx::query!(
+        r#"SELECT username FROM users WHERE email = $1"#,
+        email.to_lowercase(),
+    )
+    .fetch_one(&app.db_pool)
+    .await
+    .unwrap()
+    .username;
+    assert_eq!("pedro_g", stored_username);
 }
 
 #[tokio::test]
@@ -123,6 +191,7 @@ async fn register_stores_token_hash_not_raw_token() {
     let email = unique_email();
 
     app.post_register(&serde_json::json!({
+        "username": unique_username(),
         "email": email,
         "password": VALID_PASSWORD,
     }))
@@ -145,6 +214,7 @@ async fn login_rejects_pending_user() {
     mount_email_ok(&app).await;
     let email = unique_email();
     app.post_register(&serde_json::json!({
+        "username": unique_username(),
         "email": email,
         "password": VALID_PASSWORD,
     }))
@@ -169,6 +239,7 @@ async fn verify_email_activates_user_and_allows_login() {
     mount_email_ok(&app).await;
     let email = unique_email();
     app.post_register(&serde_json::json!({
+        "username": unique_username(),
         "email": email,
         "password": VALID_PASSWORD,
     }))
@@ -198,6 +269,7 @@ async fn verify_email_rejects_used_token() {
     mount_email_ok(&app).await;
     let email = unique_email();
     app.post_register(&serde_json::json!({
+        "username": unique_username(),
         "email": email,
         "password": VALID_PASSWORD,
     }))
@@ -225,6 +297,7 @@ async fn verify_email_rejects_expired_token() {
     mount_email_ok(&app).await;
     let email = unique_email();
     app.post_register(&serde_json::json!({
+        "username": unique_username(),
         "email": email,
         "password": VALID_PASSWORD,
     }))
@@ -256,16 +329,24 @@ async fn register_is_rate_limited() {
     mount_email_ok(&app).await;
     let max_requests = app.configuration.registration.rate_limit.max_requests;
     let email = unique_email();
-    let body = serde_json::json!({ "email": email, "password": VALID_PASSWORD });
 
-    // The first `max_requests` attempts are accepted...
+    // The first `max_requests` attempts are accepted (same email, fresh username
+    // each time, so it is the per-email rate limit being exercised)...
     for _ in 0..max_requests {
-        let response = app.post_register(&body).await;
+        let response = app
+            .post_register(&serde_json::json!({
+                "username": unique_username(), "email": email, "password": VALID_PASSWORD,
+            }))
+            .await;
         assert_eq!(StatusCode::ACCEPTED.as_u16(), response.status().as_u16());
     }
 
     // ...the next one trips the limit.
-    let limited = app.post_register(&body).await;
+    let limited = app
+        .post_register(&serde_json::json!({
+            "username": unique_username(), "email": email, "password": VALID_PASSWORD,
+        }))
+        .await;
     assert_eq!(
         StatusCode::TOO_MANY_REQUESTS.as_u16(),
         limited.status().as_u16()


### PR DESCRIPTION
## Description

- To register, a user now needs to provide a `username`, `email` & `password`.

## Motivation

Users should be able to pick their own `username`

## Changes

The register API endpoint now requires a username.
