### PR TITLE
ci: deploy to Render only from release tags, not on every main push

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,10 +1,13 @@
 name: Build and Push to GHCR then Deploy on Render
 
+# Deploy only from release tags — never from a main push. Pushing to main used
+# to build a `latest` image, publish it to GHCR and trigger a Render deploy on
+# every merge; now a package is built and Render is deployed ONLY for a tagged
+# release (v*). main is still fully validated by general.yml (fmt/clippy/tests);
+# it just no longer ships. `workflow_dispatch` keeps a manual escape hatch.
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
     tags:
       - v*
 


### PR DESCRIPTION
## Problem
`build-deploy.yml` triggered on **push to main** *and* on tags. So every merge to `main` built a `latest` container image, published it to GHCR, ran Render migrations and curled the Render deploy hook — i.e. **main auto-deployed to production**.

## Fix
Restrict the trigger to **tag pushes (`v*`)** plus manual `workflow_dispatch`. Now a package is built and Render is deployed **only for a tagged release**. `main` is still fully validated by `general.yml` (fmt / clippy / coverage) — it just no longer ships.

```diff
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
     tags:
       - v*
```

## Note (separate, your call)
`migrate_render.yaml.yml` also runs on `push: main` (when `migrations/*` change) and applies migrations to the Render DB. That's migrations, not a deploy, so I left it alone — but if you want `main` to never touch Render prod at all, say so and I'll tag-gate that one too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment workflow triggers.
  * Deployments now run for release tags or manual launches instead of merges to the main branch.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->