### PR TITLE
docs(bruno): correct Create Farm + document suggestions/moderation & directory query

### DIFF
--- a/api_docs/Admin - Approve Product Suggestion.bru
+++ b/api_docs/Admin - Approve Product Suggestion.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Admin - Approve Product Suggestion
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{URL}}/admin/product-suggestions/{{suggestion_id}}/approve
+  body: none
+  auth: inherit
+}
+
+vars:pre-request {
+  suggestion_id: 00000000-0000-0000-0000-000000000000
+}
+
+docs {
+  Approve a PENDING suggestion: links the product to the farm (as AVAILABLE) and
+  marks the suggestion APPROVED, recording the reviewer. **Admin role required.**
+
+  Responses:
+  - 200 OK: approved and applied.
+  - 404 Not Found: no PENDING suggestion with that id.
+  - 401/403: not authenticated / not an admin.
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/api_docs/Admin - List Product Suggestions.bru
+++ b/api_docs/Admin - List Product Suggestions.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Admin - List Product Suggestions
+  type: http
+  seq: 11
+}
+
+get {
+  url: {{URL}}/admin/product-suggestions
+  body: none
+  auth: inherit
+}
+
+docs {
+  Moderation queue: the PENDING product suggestions awaiting review.
+  **Admin role required** (the session user must have the ADMIN role).
+
+  Each row carries the suggestion id, the farm, the suggested product slug, an
+  optional note, and who submitted it. Approve/reject via the sibling requests.
+
+  Responses:
+  - 200 OK: list of pending suggestions.
+  - 401/403: not authenticated / not an admin.
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/api_docs/Admin - Reject Product Suggestion.bru
+++ b/api_docs/Admin - Reject Product Suggestion.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Admin - Reject Product Suggestion
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{URL}}/admin/product-suggestions/{{suggestion_id}}/reject
+  body: none
+  auth: inherit
+}
+
+vars:pre-request {
+  suggestion_id: 00000000-0000-0000-0000-000000000000
+}
+
+docs {
+  Reject a PENDING suggestion: marks it REJECTED (no farm/product link created),
+  recording the reviewer. **Admin role required.**
+
+  Responses:
+  - 200 OK: rejected.
+  - 404 Not Found: no PENDING suggestion with that id.
+  - 401/403: not authenticated / not an admin.
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/api_docs/Create Farm.bru
+++ b/api_docs/Create Farm.bru
@@ -20,21 +20,30 @@ body:json {
     "address": "Landhausweg 19, 5000 Aarau",
     "canton": "AG",
     "coordinates": "47.3925,8.0457",
-    "categories": [
-      "Organic",
-      "Fruit",
-      "Vegetables",
-      "Eggs",
-      "Flowers",
-      "Apple Juice",
-      "Meat",
-      "Jam",
-      "Bread",
-      "IP-Suisse",
-      "Ecological performance test (PEP)"
-    ],
+    "categories": ["fruits", "vegetables", "dairy"],
+    "products": ["apples", "strawberries", "eggs"],
     "idempotency_key": "95c53812-afd8-48ee-8d8c-3a35fa652ff7"
   }
+}
+
+docs {
+  Create a farm. Classification is taxonomy-aware:
+
+  - `categories`: coarse **group slugs** validated against the taxonomy
+    snapshot. Valid values: `fruits`, `vegetables`, `dairy`, `meat-poultry`,
+    `preserves`, `honey-sweeteners`, `drinks`, `bakery`, `flowers-plants`,
+    `nuts-oils`, `grains`, `fish-seafood`, `other`. Use when only group-level
+    classification is known.
+  - `products`: granular **product slugs** (e.g. `apples`, `strawberries`,
+    `eggs`), also validated against the snapshot.
+
+  At least one of `categories` / `products` is required. `coordinates` is a
+  `"lat,lng"` string. `idempotency_key` is a UUID that makes retries safe.
+
+  Responses:
+  - 201 Created (or the cached response on an idempotent retry).
+  - 400 Bad Request: unknown category/product slug, invalid canton/coordinates,
+    or no classification supplied.
 }
 
 settings {

--- a/api_docs/Get All Farms.bru
+++ b/api_docs/Get All Farms.bru
@@ -11,8 +11,6 @@ get {
 }
 
 params:query {
-  limit: 20
-  offset: 0
   ~category: fruits,vegetables
   ~product: strawberries,cherries
   ~match: all

--- a/api_docs/Get All Farms.bru
+++ b/api_docs/Get All Farms.bru
@@ -5,9 +5,49 @@ meta {
 }
 
 get {
-  url: {{URL}}/farms
+  url: {{URL}}/farms?limit=20&offset=0
   body: none
   auth: inherit
+}
+
+params:query {
+  limit: 20
+  offset: 0
+  ~category: fruits,vegetables
+  ~product: strawberries,cherries
+  ~match: all
+  ~canton: ZH,BE
+  ~q: erdbeer
+  ~lat: 47.3769
+  ~lng: 8.5417
+  ~radius_km: 25
+  ~sort: nearest
+}
+
+docs {
+  The farm directory. Returns `{ "farms": [...], "next_cursor": "<offset>" | null }`;
+  a full page hands back the next offset as `next_cursor`.
+
+  Each farm carries its granular `products[]` (slug, name_de, name_en, group,
+  stock `status`) and a derived `categories[]`; `coordinates` is a `"lat,lng"`
+  string, and `distance_km` is present when `lat`/`lng` are supplied.
+
+  Query parameters (all optional; disabled ones above are prefixed `~`):
+  - `category`  — comma-separated group slugs; matches the group directly OR via
+    a product in it ("any of").
+  - `product`   — comma-separated product slugs.
+  - `match`     — `all` requires every listed product; otherwise "any of".
+  - `canton`    — comma-separated canton codes, e.g. `ZH,BE`.
+  - `q`         — free text over farm name, address and product names (German +
+    English).
+  - `lat`/`lng` — requester location; adds `distance_km` to each farm.
+  - `radius_km` — keep only farms within this many km of `lat`/`lng`.
+  - `sort`      — `newest` (default) | `name` | `canton` | `nearest` (needs
+    `lat`/`lng`).
+  - `limit`/`offset` — page size (clamped 1-100) and offset.
+
+  400 Bad Request on an unknown category/product slug, or `nearest`/`radius_km`
+  without `lat`/`lng`.
 }
 
 settings {

--- a/api_docs/Submit Product Suggestion.bru
+++ b/api_docs/Submit Product Suggestion.bru
@@ -1,0 +1,46 @@
+meta {
+  name: Submit Product Suggestion
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{URL}}/farms/{{id}}/product-suggestions
+  body: json
+  auth: inherit
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "product": "strawberries",
+    "note": "Saw these at the farm stand last weekend."
+  }
+}
+
+vars:pre-request {
+  id: 9b67e2ef-2c4b-49c2-92d7-b2a3d88d2b61
+}
+
+docs {
+  Suggest that a farm carries a product. Community-driven; queued as PENDING for
+  admin moderation (see the Admin · Product Suggestions requests).
+
+  Body:
+  - `product`: a granular **product slug** (validated against the taxonomy).
+  - `note` (optional): free text; blank/absent is stored as NULL.
+
+  Responses:
+  - 201 Created / 200 OK: suggestion queued (idempotent per (farm, product,
+    submitter) while still PENDING).
+  - 400 Bad Request: unknown product slug or unknown farm id.
+  - 429 Too Many Requests: rate limited.
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}


### PR DESCRIPTION
Audit of the `api_docs/` Bruno collection against the current routes. Findings + fixes:

## Was wrong
- **Create Farm** — `categories` used free-text labels (`"Organic"`, `"Apple Juice"`, `"IP-Suisse"`, …). The current API validates **group slugs** against the taxonomy, so that example would **400 ("Unknown category")**. Corrected to slugs (`["fruits","vegetables","dairy"]`) and added the **new `products[]`** field (product slugs) with docs + the valid group list.

## Was missing
- **POST `/farms/{id}/product-suggestions`** (Submit Product Suggestion)
- **GET `/admin/product-suggestions`** (Admin · List — moderation queue)
- **POST `/admin/product-suggestions/{id}/approve`**
- **POST `/admin/product-suggestions/{id}/reject`**

## Was incomplete
- **Get All Farms** — now documents every directory query param (`category/product/match/canton/q/lat/lng/radius_km/sort/limit/offset`, disabled extras prefixed `~`) and the `{ farms, next_cursor }` response shape (`products[]`, `categories[]`, `distance_km`, `"lat,lng"` coordinates).

## Already correct (unchanged)
Register, Verify Email, Login, Logout, Get Current User, Get Farm, Health Check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added API documentation for submitting product suggestions to farms.
  - Added admin API documentation for listing, approving, and rejecting pending product suggestions.
  - Updated farm creation documentation to use taxonomy-aware category slugs and granular product slugs, including validation rules.
  - Expanded farms listing documentation with default pagination, filter/query semantics, location-based search details, and clearer response/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->