### PR TITLE
chore(db): least-privilege runtime role (app is not superuser/owner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,43 @@ cargo sqlx prepare --workspace --all -- --all-targets
 SKIP_DOCKER=true ./scripts/init_db.sh
 ```
 
+### Production database role (least privilege)
+
+The service **does not run migrations** — those are applied out-of-band by the
+database owner (`sqlx migrate run` / [`scripts/render_db_migrate.py`](scripts/render_db_migrate.py)).
+At runtime it therefore needs only DML, so it should **not** connect as a
+superuser or as the database owner. On managed Postgres (e.g. Render) the
+credentials you are given are never a cluster **superuser**, but they *are* the
+database **owner** — more than the running service needs.
+
+[`scripts/create_app_role.sql`](scripts/create_app_role.sql) provisions a
+dedicated `farms_app` login role with **no superuser / createdb / createrole**,
+**no ownership**, and **no CREATE on the schema** — just
+`SELECT/INSERT/UPDATE/DELETE` on the app tables (plus `ALTER DEFAULT PRIVILEGES`
+so future migrations' tables are covered automatically). Run it once as the
+owner, passing the password as a psql variable so nothing secret is committed:
+
+```bash
+psql "$OWNER_DATABASE_URL" \
+  -v app_password="$(openssl rand -base64 24)" \
+  -f scripts/create_app_role.sql
+```
+
+Then point the service at the restricted role (keep migrations running as the
+owner):
+
+```bash
+APP_DATABASE__USERNAME=farms_app
+APP_DATABASE__PASSWORD=<the password you generated>
+```
+
+Verify what a connection is actually running as:
+
+```sql
+-- expect: rolsuper = f (and, ideally, not the database owner)
+SELECT current_user, rolsuper FROM pg_roles WHERE rolname = current_user;
+```
+
 ## Docker Deployment
 
 Build and run using Docker:

--- a/README.md
+++ b/README.md
@@ -315,17 +315,21 @@ so future migrations' tables are covered automatically). Run it once as the
 owner, passing the password as a psql variable so nothing secret is committed:
 
 ```bash
-psql "$OWNER_DATABASE_URL" \
-  -v app_password="$(openssl rand -base64 24)" \
+# Generate the password into a variable so you can RETAIN it for the runtime
+# config — the script only receives it as a psql variable, never from a file.
+APP_PASSWORD="$(openssl rand -base64 24)"
+psql "$OWNER_DATABASE_URL" -v "app_password=$APP_PASSWORD" \
   -f scripts/create_app_role.sql
 ```
 
-Then point the service at the restricted role (keep migrations running as the
-owner):
+The script runs in a single transaction (atomic), so a mid-run failure can't
+leave `farms_app` with a rotated password but missing grants. Then point the
+service at the restricted role (keep migrations running as the owner) by storing
+that same value in the secret manager / environment:
 
 ```bash
 APP_DATABASE__USERNAME=farms_app
-APP_DATABASE__PASSWORD=<the password you generated>
+APP_DATABASE__PASSWORD=$APP_PASSWORD
 ```
 
 Verify what a connection is actually running as:

--- a/scripts/create_app_role.sql
+++ b/scripts/create_app_role.sql
@@ -4,27 +4,38 @@
 -- NOT apply migrations (those run out-of-band as the database owner via
 -- `sqlx migrate run` / scripts/render_db_migrate.py), so at runtime it only
 -- needs DML — SELECT / INSERT / UPDATE / DELETE. This role therefore has:
---   * NO SUPERUSER, NO CREATEDB, NO CREATEROLE
+--   * NO SUPERUSER, NO CREATEDB, NO CREATEROLE, NO BYPASSRLS, NO REPLICATION
 --   * NO ownership of the database or its tables (cannot DROP/ALTER schema)
 --   * NO CREATE on the schema (cannot add its own objects)
 --   * only DML on the application tables + sequence access for IDENTITY columns
 --
 -- Run this ONCE as the database owner/admin (on Render, the credentials in the
--- service's own connection string are the owner). Pass the app password as a
--- psql variable so no secret is committed:
+-- service's own connection string are the owner). Generate the password into a
+-- shell variable so you can RETAIN it for the runtime config — the script only
+-- ever receives it as a psql variable, never from this file:
 --
---   psql "$OWNER_DATABASE_URL" \
---     -v app_password="$(openssl rand -base64 24)" \
+--   APP_PASSWORD="$(openssl rand -base64 24)"
+--   psql "$OWNER_DATABASE_URL" -v "app_password=$APP_PASSWORD" \
 --     -f scripts/create_app_role.sql
 --
--- Then point the service at the new role (leave migrations running as the owner):
+-- Then store that same value in the service's secret manager / environment
+-- (leave migrations running as the owner):
 --   APP_DATABASE__USERNAME=farms_app
---   APP_DATABASE__PASSWORD=<the password you generated above>
+--   APP_DATABASE__PASSWORD=$APP_PASSWORD
 --
 -- Re-running is safe: it is idempotent and also rotates the password to the
--- value you pass in.
+-- value you pass in. The whole thing runs in ONE transaction, so a failure
+-- part-way can't leave farms_app with a rotated password but missing grants.
+--
+-- ⚠ Reuse caveat: if a `farms_app` role already exists, this resets its role
+-- attributes and re-applies the grants, but it does NOT drop pre-existing table
+-- ownership or role memberships it may have accumulated. For a guaranteed
+-- clean slate, DROP the role first (reassign or drop any objects it owns) and
+-- let this script recreate it.
 
 \set ON_ERROR_STOP on
+
+BEGIN;
 
 -- 1. The login role. Created only if missing; the password always comes from
 --    the :app_password variable, never from this file.
@@ -32,9 +43,12 @@ SELECT format('CREATE ROLE farms_app LOGIN PASSWORD %L', :'app_password')
 WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'farms_app')
 \gexec
 
--- Keep the password in step on re-runs (supports rotation) and pin the role to
--- the least-privilege attributes even if it existed before.
-SELECT format('ALTER ROLE farms_app LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE PASSWORD %L', :'app_password')
+-- Pin the role to the least-privilege attributes even if it existed before
+-- (stripping any SUPERUSER/CREATEDB/CREATEROLE/BYPASSRLS/REPLICATION it may have
+-- carried), and rotate the password to the value passed in.
+SELECT format(
+  'ALTER ROLE farms_app LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE '
+  'NOBYPASSRLS NOREPLICATION PASSWORD %L', :'app_password')
 \gexec
 
 -- 2. Connect + read the schema, but not create in it. Grant CONNECT on whatever
@@ -56,3 +70,5 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO farms_app;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT USAGE, SELECT ON SEQUENCES TO farms_app;
+
+COMMIT;

--- a/scripts/create_app_role.sql
+++ b/scripts/create_app_role.sql
@@ -1,0 +1,58 @@
+-- Provision a LEAST-PRIVILEGE runtime role for the farms service.
+--
+-- Why: the running service should never hold more power than it uses. It does
+-- NOT apply migrations (those run out-of-band as the database owner via
+-- `sqlx migrate run` / scripts/render_db_migrate.py), so at runtime it only
+-- needs DML — SELECT / INSERT / UPDATE / DELETE. This role therefore has:
+--   * NO SUPERUSER, NO CREATEDB, NO CREATEROLE
+--   * NO ownership of the database or its tables (cannot DROP/ALTER schema)
+--   * NO CREATE on the schema (cannot add its own objects)
+--   * only DML on the application tables + sequence access for IDENTITY columns
+--
+-- Run this ONCE as the database owner/admin (on Render, the credentials in the
+-- service's own connection string are the owner). Pass the app password as a
+-- psql variable so no secret is committed:
+--
+--   psql "$OWNER_DATABASE_URL" \
+--     -v app_password="$(openssl rand -base64 24)" \
+--     -f scripts/create_app_role.sql
+--
+-- Then point the service at the new role (leave migrations running as the owner):
+--   APP_DATABASE__USERNAME=farms_app
+--   APP_DATABASE__PASSWORD=<the password you generated above>
+--
+-- Re-running is safe: it is idempotent and also rotates the password to the
+-- value you pass in.
+
+\set ON_ERROR_STOP on
+
+-- 1. The login role. Created only if missing; the password always comes from
+--    the :app_password variable, never from this file.
+SELECT format('CREATE ROLE farms_app LOGIN PASSWORD %L', :'app_password')
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'farms_app')
+\gexec
+
+-- Keep the password in step on re-runs (supports rotation) and pin the role to
+-- the least-privilege attributes even if it existed before.
+SELECT format('ALTER ROLE farms_app LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE PASSWORD %L', :'app_password')
+\gexec
+
+-- 2. Connect + read the schema, but not create in it. Grant CONNECT on whatever
+--    database this script is run against (the name differs on Render).
+SELECT format('GRANT CONNECT ON DATABASE %I TO farms_app', current_database())
+\gexec
+GRANT USAGE ON SCHEMA public TO farms_app;
+
+-- 3. DML on every existing table, plus USAGE/SELECT on sequences (harmless for
+--    GENERATED … AS IDENTITY columns, required should any SERIAL be added).
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO farms_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO farms_app;
+
+-- 4. Cover tables/sequences that FUTURE migrations create, so this never has to
+--    be re-run after a deploy. ALTER DEFAULT PRIVILEGES applies to objects
+--    created from now on by the role that runs it — i.e. the owner running
+--    migrations. (Run this script AS that owner for the defaults to line up.)
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO farms_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO farms_app;


### PR DESCRIPTION
## Question this answers
> for security reasons, and so that the auth code is well implemented, the app should not be a superuser right?

**Right.** And we can go one better than "not a superuser".

## Current state
- The service **does not run migrations** (no `sqlx::migrate!` in `src/`) — they're applied out-of-band by the DB owner (`sqlx migrate run` / `scripts/render_db_migrate.py`). So the runtime only ever needs **DML**.
- On Render, the managed-DB credentials are **never a cluster superuser**, but they **are the database owner** — which can `DROP`/`ALTER` the schema. That's more power than the running service uses.

## What this adds
[`scripts/create_app_role.sql`](../blob/chore/least-privilege-db-role/scripts/create_app_role.sql) provisions a dedicated `farms_app` login role:
- **NO** superuser / createdb / createrole
- **NO** ownership, **NO** `CREATE` on the schema
- only `SELECT/INSERT/UPDATE/DELETE` on the app tables
- `ALTER DEFAULT PRIVILEGES` so tables from future migrations are covered automatically

Password is passed as a psql variable (`-v app_password=…`) — nothing secret is committed. Idempotent + supports rotation.

Wire-up (keep migrations running as the owner):
```
APP_DATABASE__USERNAME=farms_app
APP_DATABASE__PASSWORD=<generated>
```

## Verified (postgres:18, all migrations applied)
Acting **as `farms_app`**:
| operation | result |
|---|---|
| `SELECT` / `INSERT` / `UPDATE` / `DELETE` | ✅ permitted |
| `CREATE TABLE` | ❌ `permission denied for schema public` |
| `DROP TABLE farms` | ❌ `must be owner of table farms` |
| `ALTER TABLE farms` | ❌ `must be owner of table farms` |

Role attributes: `rolsuper=f, rolcreatedb=f, rolcreaterole=f, rolcanlogin=t`.

> Note: I couldn't introspect the live Render DB from here (no Render MCP connected this session). Run the verification query in the README against production to confirm what the service currently connects as; if it's the owner, create `farms_app` and switch `APP_DATABASE__USERNAME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Production database role (least privilege)” section with setup instructions, environment variable configuration, and verification steps to ensure non-superuser access.
* **New Features**
  * Added an idempotent SQL script to provision and maintain a restricted PostgreSQL runtime role, including permission grants for existing objects and default privileges for future tables/sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->