### PR TITLE
fix(farms): serialize StockStatus as SCREAMING_SNAKE_CASE (frontend contract)

### DIFF
--- a/src/domain/farm/stock_status.rs
+++ b/src/domain/farm/stock_status.rs
@@ -1,10 +1,43 @@
 //! Per-(farm, product) availability state.
 
+// JSON casing MUST match the PostgreSQL enum labels (SCREAMING_SNAKE_CASE) so
+// the wire value equals the stored value — `AVAILABLE`, `SEASONAL`,
+// `UNAVAILABLE`. The frontend's `StockStatus` union and the Bruno docs expect
+// exactly these. (An earlier `snake_case` serde attr silently shipped
+// lowercase JSON, which the frontend's `status === "AVAILABLE"` checks never
+// matched.)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::Type, serde::Serialize, serde::Deserialize)]
 #[sqlx(type_name = "stock_status", rename_all = "SCREAMING_SNAKE_CASE")]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum StockStatus {
     Available,
     Seasonal,
     Unavailable,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StockStatus;
+
+    #[test]
+    fn serializes_to_screaming_snake_case_matching_the_db_and_frontend() {
+        assert_eq!(
+            serde_json::to_string(&StockStatus::Available).unwrap(),
+            "\"AVAILABLE\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StockStatus::Seasonal).unwrap(),
+            "\"SEASONAL\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StockStatus::Unavailable).unwrap(),
+            "\"UNAVAILABLE\""
+        );
+    }
+
+    #[test]
+    fn deserializes_from_the_same_uppercase_labels() {
+        let parsed: StockStatus = serde_json::from_str("\"SEASONAL\"").unwrap();
+        assert_eq!(parsed, StockStatus::Seasonal);
+    }
 }


### PR DESCRIPTION
## The bug (found while re-verifying the frontend↔backend contract)
Each product's `status` serialized to **lowercase** JSON — `"available"` / `"seasonal"` / `"unavailable"` — because of a stray `#[serde(rename_all = "snake_case")]` on `StockStatus`. But:
- the **PostgreSQL** enum labels are `AVAILABLE` / `SEASONAL` / `UNAVAILABLE` (`#[sqlx(rename_all = "SCREAMING_SNAKE_CASE")]`),
- the **frontend** type is `type StockStatus = "AVAILABLE" | "SEASONAL" | "UNAVAILABLE"`,
- the **Bruno docs** use the uppercase labels.

So the frontend's checks in `FarmDetail.tsx` never matched the wire value:
```ts
item.status !== "AVAILABLE"   // always true  → every product shows a badge
item.status === "SEASONAL"    // always false → seasonal styling never applies
STOCK_LABEL_KEY[item.status]  // STOCK_LABEL_KEY["available"] → undefined → empty label
```
Result on the farm detail page: **available products wrongly render a stock badge with an empty label**, and seasonal/unavailable states never display correctly.

## Fix
One line: `#[serde(rename_all = "SCREAMING_SNAKE_CASE")]`, aligning the JSON with the DB labels and the frontend. The wire value now equals the stored value.

## Safety
`StockStatus` is only **serialized** in `GET /farms` responses and **decoded from the DB via sqlx** (its own mapping, unaffected). No request body deserializes it from a client, so no caller breaks. The moderation integration test reads the DB value (already uppercase) and is unaffected.

## Tests
Added unit tests locking the casing in both directions (`"AVAILABLE"` ⇄ `Available`). `cargo test --lib stock_status` → 2 passed; crate compiles; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)