### PR TITLE
feat: i18n - define the supported API languages and accept ?lang=

### DIFF
--- a/src/domain/language.rs
+++ b/src/domain/language.rs
@@ -31,7 +31,13 @@ pub enum Language {
 
 #[derive(Debug, thiserror::Error)]
 pub enum LanguageError {
-    #[error("Unsupported language '{0}'. Supported languages are: en, de, fr, it, rm.")]
+    // Generated from `ALL` rather than spelled out, so the message cannot drift
+    // from the set actually accepted. A hardcoded list would still compile, and
+    // still read plausibly, after a language was added.
+    #[error(
+        "Unsupported language '{0}'. Supported languages are: {codes}.",
+        codes = Language::ALL.map(|language| language.code()).join(", ")
+    )]
     Unsupported(String),
 }
 
@@ -152,7 +158,15 @@ mod tests {
         // so a caller can fix the request without reading the source.
         let message = error.to_string();
         assert!(message.contains("es"), "got: {message}");
-        assert!(message.contains("en, de, fr, it, rm"), "got: {message}");
+        // Checked against ALL rather than a frozen "en, de, fr, it, rm": a
+        // literal here would keep passing after a sixth language was added,
+        // while the message quietly told callers it was unsupported.
+        for language in Language::ALL {
+            assert!(
+                message.contains(language.code()),
+                "{language} is supported but missing from: {message}"
+            );
+        }
     }
 
     #[test]

--- a/src/domain/language.rs
+++ b/src/domain/language.rs
@@ -1,0 +1,205 @@
+//! Supported API languages.
+//!
+//! The API separates *stable keys* from *display labels*: filtering always uses
+//! language-independent slugs, while the language selected here only decides
+//! which human-readable label is returned. That split is what lets a caller ask
+//! for `?category=vegetables&lang=de` and get German text back without the
+//! filter itself becoming language-dependent.
+//!
+//! Switzerland has four national languages, and the platform additionally
+//! serves English, so five codes are supported.
+
+use std::fmt::Display;
+use std::str::FromStr;
+
+/// A language the API can return display labels in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Language {
+    /// English — also the fallback when a translation is missing.
+    #[default]
+    En,
+    /// German (Deutsch).
+    De,
+    /// French (français).
+    Fr,
+    /// Italian (italiano).
+    It,
+    /// Romansh (rumantsch).
+    Rm,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LanguageError {
+    #[error("Unsupported language '{0}'. Supported languages are: en, de, fr, it, rm.")]
+    Unsupported(String),
+}
+
+impl Language {
+    /// Every supported language, in a stable order suitable for documentation
+    /// and for building an "available languages" response.
+    pub const ALL: [Language; 5] = [
+        Language::En,
+        Language::De,
+        Language::Fr,
+        Language::It,
+        Language::Rm,
+    ];
+
+    /// The two-letter code, as accepted by `?lang=` and returned in responses.
+    pub fn code(self) -> &'static str {
+        match self {
+            Language::En => "en",
+            Language::De => "de",
+            Language::Fr => "fr",
+            Language::It => "it",
+            Language::Rm => "rm",
+        }
+    }
+
+    /// Parse a language tag.
+    ///
+    /// Accepts a bare code (`de`) or a regional tag (`de-CH`, `de_CH`), because
+    /// browsers and mobile clients routinely send the regional form and every
+    /// Swiss regional variant maps onto the same label set we hold. Matching is
+    /// case-insensitive: `DE`, `de` and `de-CH` are the same request.
+    pub fn parse(value: &str) -> Result<Self, LanguageError> {
+        let trimmed = value.trim();
+        // Take the primary subtag: "de-CH" and "de_CH" both mean German here.
+        let primary = trimmed
+            .split(['-', '_'])
+            .next()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+
+        match primary.as_str() {
+            "en" => Ok(Language::En),
+            "de" => Ok(Language::De),
+            "fr" => Ok(Language::Fr),
+            "it" => Ok(Language::It),
+            "rm" => Ok(Language::Rm),
+            // Report the caller's original input, not the normalised primary
+            // subtag, so the message names what they actually sent.
+            _ => Err(LanguageError::Unsupported(trimmed.to_string())),
+        }
+    }
+
+    /// Resolve an optional `?lang=` value, defaulting when it is absent.
+    ///
+    /// An absent language is not an error — it selects the default. An
+    /// unsupported one is, matching how unknown category and product slugs are
+    /// rejected rather than silently ignored: a caller who asked for something
+    /// specific should hear that they did not get it.
+    pub fn from_query(value: Option<&str>) -> Result<Self, LanguageError> {
+        match value {
+            None => Ok(Language::default()),
+            // `?lang=` with no value reads as "unset" rather than as a typo.
+            Some(raw) if raw.trim().is_empty() => Ok(Language::default()),
+            Some(raw) => Language::parse(raw),
+        }
+    }
+}
+
+impl Display for Language {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.code())
+    }
+}
+
+impl FromStr for Language {
+    type Err = LanguageError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Language::parse(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_every_supported_code() {
+        for language in Language::ALL {
+            assert_eq!(Language::parse(language.code()).unwrap(), language);
+        }
+    }
+
+    #[test]
+    fn parsing_is_case_insensitive() {
+        assert_eq!(Language::parse("DE").unwrap(), Language::De);
+        assert_eq!(Language::parse("Rm").unwrap(), Language::Rm);
+    }
+
+    #[test]
+    fn accepts_regional_tags() {
+        // Swiss clients commonly send these; they all want the same labels.
+        for tag in ["de-CH", "de_CH", "fr-CH", "it-CH", "rm-CH", "en-GB"] {
+            assert!(Language::parse(tag).is_ok(), "expected {tag} to parse");
+        }
+        assert_eq!(Language::parse("de-CH").unwrap(), Language::De);
+    }
+
+    #[test]
+    fn ignores_surrounding_whitespace() {
+        assert_eq!(Language::parse("  fr  ").unwrap(), Language::Fr);
+    }
+
+    #[test]
+    fn rejects_an_unsupported_language() {
+        let error = Language::parse("es").unwrap_err();
+        // The message must name the offending input and list what is allowed,
+        // so a caller can fix the request without reading the source.
+        let message = error.to_string();
+        assert!(message.contains("es"), "got: {message}");
+        assert!(message.contains("en, de, fr, it, rm"), "got: {message}");
+    }
+
+    #[test]
+    fn reports_the_original_input_not_the_primary_subtag() {
+        let message = Language::parse("es-AR").unwrap_err().to_string();
+        assert!(message.contains("es-AR"), "got: {message}");
+    }
+
+    #[test]
+    fn rejects_nonsense_that_merely_starts_with_a_valid_code() {
+        // "den" must not be accepted as German: only a subtag boundary counts.
+        assert!(Language::parse("den").is_err());
+        assert!(Language::parse("english").is_err());
+    }
+
+    #[test]
+    fn english_is_the_default() {
+        assert_eq!(Language::default(), Language::En);
+        assert_eq!(Language::from_query(None).unwrap(), Language::En);
+    }
+
+    #[test]
+    fn an_empty_lang_parameter_selects_the_default() {
+        assert_eq!(Language::from_query(Some("")).unwrap(), Language::En);
+        assert_eq!(Language::from_query(Some("   ")).unwrap(), Language::En);
+    }
+
+    #[test]
+    fn from_query_rejects_an_unsupported_value() {
+        assert!(Language::from_query(Some("es")).is_err());
+    }
+
+    #[test]
+    fn serializes_as_its_lowercase_code() {
+        let json = serde_json::to_string(&Language::De).unwrap();
+        assert_eq!(json, "\"de\"");
+    }
+
+    #[test]
+    fn displays_as_its_code() {
+        assert_eq!(Language::De.to_string(), "de");
+        assert_eq!(Language::Rm.to_string(), "rm");
+    }
+
+    #[test]
+    fn from_str_matches_parse() {
+        let via_from_str: Language = "it".parse().unwrap();
+        assert_eq!(via_from_str, Language::parse("it").unwrap());
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -6,5 +6,6 @@ pub mod test_data;
 
 // Domain entities
 pub mod farm;
+pub mod language;
 pub mod suggestion;
 pub mod user;

--- a/src/routes/farms/get.rs
+++ b/src/routes/farms/get.rs
@@ -1,5 +1,6 @@
 use crate::{
     domain::farm::{Address, Canton, Name, Point, StockStatus},
+    domain::language::Language,
     routes::farms::{FarmError, FarmListResponse, FarmResponse, FarmRow, ProductDto},
     taxonomy::TaxonomySnapshot,
 };
@@ -8,6 +9,13 @@ use anyhow::Context;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use uuid::Uuid;
+
+/// Query parameters accepted by `GET /farms/{id}`.
+#[derive(Debug, serde::Deserialize)]
+pub struct FarmDetailQuery {
+    /// Display language for labels — see `FarmListQuery::lang`.
+    pub lang: Option<String>,
+}
 
 #[derive(Debug, serde::Deserialize)]
 pub struct FarmPath {
@@ -35,6 +43,9 @@ pub struct FarmListQuery {
     pub radius_km: Option<f64>,
     /// `newest` (default) | `name` | `canton` | `nearest` (needs lat/lng).
     pub sort: Option<String>,
+    /// Display language for labels: `en` (default) | `de` | `fr` | `it` | `rm`.
+    /// Filtering is unaffected — slugs stay language-independent.
+    pub lang: Option<String>,
     #[serde(default = "default_limit")]
     pub limit: i64,
     #[serde(default)]
@@ -65,6 +76,10 @@ pub async fn get_all(
 ) -> Result<HttpResponse, FarmError> {
     let limit = query.limit.clamp(1, 100);
     let offset = query.offset.max(0);
+    // Resolve the display language up front so an unsupported code fails the
+    // request before any database work, the same way unknown slugs do.
+    let language = Language::from_query(query.lang.as_deref())
+        .map_err(|e| FarmError::ValidationError(e.to_string()))?;
     let sort = query.sort.as_deref().unwrap_or("newest");
 
     // Resolve product slugs to ids (early 400 on any unknown slug).
@@ -128,7 +143,11 @@ pub async fn get_all(
         None
     };
 
-    Ok(HttpResponse::Ok().json(FarmListResponse { farms, next_cursor }))
+    Ok(HttpResponse::Ok().json(FarmListResponse {
+        farms,
+        next_cursor,
+        lang: language,
+    }))
 }
 
 /// Resolve a comma-separated slug list to ids via `resolver`, 400 on unknown.
@@ -354,8 +373,14 @@ async fn load_products(
 #[tracing::instrument(name = "Get farm by id", skip(pool))]
 pub async fn get_by_id(
     path: web::Path<FarmPath>,
+    query: web::Query<FarmDetailQuery>,
     pool: web::Data<PgPool>,
 ) -> Result<HttpResponse, FarmError> {
+    // Validate the language even though the detail response does not vary by it
+    // yet: rejecting `?lang=es` consistently on both endpoints means clients
+    // learn the contract from either one, and the labels land in #128/#129.
+    let _language = Language::from_query(query.lang.as_deref())
+        .map_err(|e| FarmError::ValidationError(e.to_string()))?;
     let farm_id = Uuid::parse_str(&path.id)
         .map_err(|_| FarmError::ValidationError("Invalid farm id.".to_string()))?;
 

--- a/src/routes/farms/get.rs
+++ b/src/routes/farms/get.rs
@@ -1,7 +1,9 @@
 use crate::{
     domain::farm::{Address, Canton, Name, Point, StockStatus},
     domain::language::Language,
-    routes::farms::{FarmError, FarmListResponse, FarmResponse, FarmRow, ProductDto},
+    routes::farms::{
+        FarmDetailResponse, FarmError, FarmListResponse, FarmResponse, FarmRow, ProductDto,
+    },
     taxonomy::TaxonomySnapshot,
 };
 use actix_web::{HttpResponse, web};
@@ -376,16 +378,16 @@ pub async fn get_by_id(
     query: web::Query<FarmDetailQuery>,
     pool: web::Data<PgPool>,
 ) -> Result<HttpResponse, FarmError> {
-    // Validate the language even though the detail response does not vary by it
-    // yet: rejecting `?lang=es` consistently on both endpoints means clients
-    // learn the contract from either one, and the labels land in #128/#129.
-    let _language = Language::from_query(query.lang.as_deref())
+    let language = Language::from_query(query.lang.as_deref())
         .map_err(|e| FarmError::ValidationError(e.to_string()))?;
     let farm_id = Uuid::parse_str(&path.id)
         .map_err(|_| FarmError::ValidationError("Invalid farm id.".to_string()))?;
 
     match get_farm_by_id(farm_id, &pool).await? {
-        Some(farm) => Ok(HttpResponse::Ok().json(farm)),
+        Some(farm) => Ok(HttpResponse::Ok().json(FarmDetailResponse {
+            farm,
+            lang: language,
+        })),
         None => Err(FarmError::NotFound),
     }
 }

--- a/src/routes/farms/mod.rs
+++ b/src/routes/farms/mod.rs
@@ -46,6 +46,23 @@ pub struct FarmResponse {
     pub updated_at: Option<DateTime<Utc>>,
 }
 
+/// A single farm plus the language it was resolved for.
+///
+/// The list endpoint echoes `lang` at the top level, and the detail endpoint
+/// has to as well — a client should be able to read the same field from either
+/// without a special case. Flattened, so every existing field stays exactly
+/// where it was and adding this moves nothing a caller already reads.
+///
+/// It lives here rather than on `FarmResponse` because that type is also the
+/// element type of the list, where repeating the language on all hundred farms
+/// would say the same thing a hundred times.
+#[derive(serde::Serialize)]
+pub struct FarmDetailResponse {
+    #[serde(flatten)]
+    pub farm: FarmResponse,
+    pub lang: Language,
+}
+
 /// A page of farms plus the offset to fetch the next page (if any).
 #[derive(serde::Serialize)]
 pub struct FarmListResponse {

--- a/src/routes/farms/mod.rs
+++ b/src/routes/farms/mod.rs
@@ -1,4 +1,5 @@
 use crate::domain::farm::{Address, Canton, Name, Point, StockStatus};
+use crate::domain::language::Language;
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
@@ -51,6 +52,13 @@ pub struct FarmListResponse {
     pub farms: Vec<FarmResponse>,
     /// Offset for the next page as a string, or null when this is the last page.
     pub next_cursor: Option<String>,
+    /// The language the labels in this response were resolved to.
+    ///
+    /// Echoing it back means a caller can tell the difference between "you got
+    /// German because you asked" and "you got the default", without having to
+    /// infer it from the payload. It is also what makes an omitted `lang`
+    /// self-documenting.
+    pub lang: Language,
 }
 
 /// The raw farm row loaded from the database, before products are attached.

--- a/tests/api/language.rs
+++ b/tests/api/language.rs
@@ -170,3 +170,35 @@ async fn language_does_not_change_which_farms_match() {
         "result count varied by language: {counts:?}"
     );
 }
+
+#[tokio::test]
+async fn the_detail_endpoint_echoes_the_language_too() {
+    // The list endpoint reports which language it resolved to; the detail one
+    // must as well, or a client has to special-case which response it is
+    // reading to answer the same question.
+    let app = spawn_app(IdempotencyEngine::None).await;
+    let farm_id = insert_test_farm(&app.db_pool, "Echo Farm").await;
+
+    for (query, expected) in [
+        ("", "en"),
+        ("?lang=de", "de"),
+        ("?lang=fr-CH", "fr"),
+        ("?lang=", "en"),
+    ] {
+        let body: serde_json::Value = app
+            .api_client
+            .get(format!("{}/farms/{farm_id}{query}", app.address))
+            .send()
+            .await
+            .expect("Failed to execute request.")
+            .json()
+            .await
+            .unwrap();
+
+        assert_eq!(body["lang"], expected, "query={query:?}");
+        // Flattened, so the farm's own fields stay exactly where they were.
+        assert_eq!(body["id"], farm_id.to_string(), "query={query:?}");
+        assert_eq!(body["name"], "Echo Farm", "query={query:?}");
+        assert!(body["products"].is_array(), "query={query:?}");
+    }
+}

--- a/tests/api/language.rs
+++ b/tests/api/language.rs
@@ -1,0 +1,172 @@
+use crate::helpers::{insert_test_farm, spawn_app};
+use actix_web::http::StatusCode;
+use farms::configuration::IdempotencyEngine;
+
+/// The `lang` the server resolved for a list request.
+async fn resolved_lang(response: reqwest::Response) -> String {
+    let body: serde_json::Value = response.json().await.unwrap();
+    body["lang"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn defaults_to_english_when_no_language_is_requested() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Default Language Farm").await;
+
+    let response = app
+        .api_client
+        .get(format!("{}/farms", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    // Echoing the resolution back is what lets a client tell "defaulted" apart
+    // from "honoured my request".
+    assert_eq!(resolved_lang(response).await, "en");
+}
+
+#[tokio::test]
+async fn honours_every_supported_language() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Multilingual Farm").await;
+
+    for code in ["en", "de", "fr", "it", "rm"] {
+        let response = app
+            .api_client
+            .get(format!("{}/farms?lang={code}", app.address))
+            .send()
+            .await
+            .expect("Failed to execute request.");
+
+        assert_eq!(
+            response.status().as_u16(),
+            StatusCode::OK.as_u16(),
+            "lang={code}"
+        );
+        assert_eq!(resolved_lang(response).await, code);
+    }
+}
+
+#[tokio::test]
+async fn accepts_a_regional_tag_and_reports_the_base_language() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Swiss German Farm").await;
+
+    // Swiss clients commonly send de-CH; it must not be a client error.
+    let response = app
+        .api_client
+        .get(format!("{}/farms?lang=de-CH", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    assert_eq!(resolved_lang(response).await, "de");
+}
+
+#[tokio::test]
+async fn is_case_insensitive() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Shouty Farm").await;
+
+    let response = app
+        .api_client
+        .get(format!("{}/farms?lang=DE", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    assert_eq!(resolved_lang(response).await, "de");
+}
+
+#[tokio::test]
+async fn rejects_an_unsupported_language_with_400() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+
+    let response = app
+        .api_client
+        .get(format!("{}/farms?lang=es", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Consistent with unknown category/product slugs: a caller who asked for
+    // something specific is told they did not get it.
+    assert_eq!(response.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
+    let body = response.text().await.unwrap();
+    assert!(body.contains("es"), "message should name the input: {body}");
+    assert!(
+        body.contains("en, de, fr, it, rm"),
+        "message should list the supported codes: {body}"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_language_parameter_falls_back_to_the_default() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Empty Lang Farm").await;
+
+    // `?lang=` reads as "unset", not as a typo.
+    let response = app
+        .api_client
+        .get(format!("{}/farms?lang=", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    assert_eq!(resolved_lang(response).await, "en");
+}
+
+#[tokio::test]
+async fn the_detail_endpoint_validates_the_language_too() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    let farm = insert_test_farm(&app.db_pool, "Detail Farm").await;
+
+    let ok = app
+        .api_client
+        .get(format!("{}/farms/{farm}?lang=fr", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+    assert_eq!(ok.status().as_u16(), StatusCode::OK.as_u16());
+
+    // Both endpoints reject the same way, so the contract is learnable from
+    // either one.
+    let rejected = app
+        .api_client
+        .get(format!("{}/farms/{farm}?lang=es", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+    assert_eq!(rejected.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
+}
+
+#[tokio::test]
+async fn language_does_not_change_which_farms_match() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Stable Keys Farm").await;
+    insert_test_farm(&app.db_pool, "Another Farm").await;
+
+    // The whole point of separating keys from labels: switching language must
+    // never change the result set, only how it reads.
+    let mut counts = Vec::new();
+    for code in ["en", "de", "fr", "it", "rm"] {
+        let body: serde_json::Value = app
+            .api_client
+            .get(format!("{}/farms?lang={code}", app.address))
+            .send()
+            .await
+            .expect("Failed to execute request.")
+            .json()
+            .await
+            .unwrap();
+        counts.push(body["farms"].as_array().unwrap().len());
+    }
+    assert!(
+        counts.windows(2).all(|w| w[0] == w[1]),
+        "result count varied by language: {counts:?}"
+    );
+}

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -5,6 +5,7 @@ mod authentication;
 mod directory;
 mod farms;
 mod health_check;
+mod language;
 mod me;
 mod moderation;
 mod products;


### PR DESCRIPTION
Closes #127. First of five stacked PRs for epic #126.

## What this adds

A `Language` type covering the five codes the platform serves — `en`, `de`, `fr`, `it`, `rm` — and `?lang=` on both farm endpoints.

## Decisions worth reviewing

**Regional tags are accepted.** `de-CH`, `de_CH` and `de` all resolve to German. Swiss browsers and mobile clients routinely send the regional form, and every Swiss variant maps onto the same label set we hold, so rejecting them would fail requests we can answer perfectly well. Parsing splits on the subtag boundary, so `den` and `english` are still errors rather than sloppy prefix matches.

**An absent language defaults; an unsupported one is a 400.** These are different situations: a caller who sent nothing expressed no preference, while a caller who asked for Spanish should hear that they did not get it rather than silently receive English. The 400 matches how unknown category and product slugs are already handled. `?lang=` with an empty value reads as "unset", not as a typo.

**The list response echoes the resolved language.** Without it there is no way to distinguish "German because I asked" from "the default", and an omitted `lang` has no observable answer at all. It is additive, so existing clients are unaffected.

**The detail endpoint validates but does not yet vary.** Labels arrive in #128/#129. Rejecting `?lang=es` consistently on both endpoints now means clients learn the contract from whichever they hit first, instead of finding out later that one is stricter than the other.

## Filtering is deliberately untouched

The premise of #132 is that filters use stable slugs, not translated labels. A test asserts the result count is identical across all five languages — switching language must change how results read, never which rows match.

## Verification

- 13 unit tests on the type: every code, case-insensitivity, regional tags, whitespace, default, and the rejections
- 8 integration tests on the endpoints, including that both reject identically
- full suite green: **161 unit + 85 integration**
- `cargo fmt`, `clippy -D warnings` clean, `.sqlx` regenerated

## Stack

```
#127  ← this PR
 └── #128  localised product labels
      └── #129  localised category labels
           └── #130  fallback behaviour
                └── #131  documentation
```

Each targets its parent, so please merge in order — bottom-up merges would conflict on the shared migration and taxonomy files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language selection for farm list and detail requests.
  * Supports English, German, French, Italian, and Romansh, including regional and case-insensitive language tags.
  * Farm list and detail responses now report the resolved language.
  * Requests without a language, or with an empty value, default to English.

* **Bug Fixes**
  * Unsupported language values now return clear validation errors consistently across farm endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->