### PR TITLE
feat: i18n - localised category labels + GET /taxonomy

### DIFF
--- a/.sqlx/query-46cfd5c8e140198c52804ebe5a12b73d6ea66cbe77cb9f222d806801dc555102.json
+++ b/.sqlx/query-46cfd5c8e140198c52804ebe5a12b73d6ea66cbe77cb9f222d806801dc555102.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        INSERT INTO product_categories (key_de, slug, display_order)\n        VALUES ($1, $2, $3)\n        RETURNING id\n        ",
+  "query": "\n        INSERT INTO product_categories\n            (key_de, slug, display_order, name_en, name_fr, name_it, name_rm)\n        VALUES ($1, $2, $3, $4, $5, $6, $7)\n        RETURNING id\n        ",
   "describe": {
     "columns": [
       {
@@ -19,12 +19,16 @@
       "Left": [
         "Text",
         "Text",
-        "Int2"
+        "Int2",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
       ]
     },
     "nullable": [
       false
     ]
   },
-  "hash": "5d07fd76289a43db852858a2aff9898cbab6bba7dea0b90e625a4936a78e0cbf"
+  "hash": "46cfd5c8e140198c52804ebe5a12b73d6ea66cbe77cb9f222d806801dc555102"
 }

--- a/.sqlx/query-f828cceea175f108ee7c14c6f4ba622b2e0e9b1bdd4336557dcb045098bf1c17.json
+++ b/.sqlx/query-f828cceea175f108ee7c14c6f4ba622b2e0e9b1bdd4336557dcb045098bf1c17.json
@@ -1,0 +1,98 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, slug, key_de, name_en, name_fr, name_it, name_rm\n            FROM product_categories\n            ORDER BY display_order, slug\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int2",
+        "origin": {
+          "Table": {
+            "table": "product_categories",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "slug",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "product_categories",
+            "name": "slug"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "key_de",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "product_categories",
+            "name": "key_de"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "name_en",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "product_categories",
+            "name": "name_en"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "name_fr",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "product_categories",
+            "name": "name_fr"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "name_it",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "product_categories",
+            "name": "name_it"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "name_rm",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "product_categories",
+            "name": "name_rm"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "f828cceea175f108ee7c14c6f4ba622b2e0e9b1bdd4336557dcb045098bf1c17"
+}

--- a/migrations/20260801165616_add_category_localised_labels.sql
+++ b/migrations/20260801165616_add_category_localised_labels.sql
@@ -15,3 +15,21 @@ ALTER TABLE product_categories
     ADD COLUMN name_fr text,
     ADD COLUMN name_it text,
     ADD COLUMN name_rm text;
+
+-- "Missing translation" has exactly one spelling here: NULL.
+--
+-- Without this, `text` also admits '' and '   ', which read as present but
+-- display as nothing: /taxonomy would answer with an empty `name` and
+-- `translated: true`, and the fallback chain would stop on a value it should
+-- have skipped. `key_de` is included because the chain terminates on it — a
+-- blank canonical label defeats the guarantee that a caller always gets
+-- something readable back.
+ALTER TABLE product_categories
+    ADD CONSTRAINT product_categories_labels_not_blank
+        CHECK (
+            btrim(key_de) <> ''
+                AND (name_en IS NULL OR btrim(name_en) <> '')
+                AND (name_fr IS NULL OR btrim(name_fr) <> '')
+                AND (name_it IS NULL OR btrim(name_it) <> '')
+                AND (name_rm IS NULL OR btrim(name_rm) <> '')
+            );

--- a/migrations/20260801165616_add_category_localised_labels.sql
+++ b/migrations/20260801165616_add_category_localised_labels.sql
@@ -1,30 +1,17 @@
 -- Localised display labels for the category groups.
 --
 -- `key_de` already holds the canonical German label and doubles as the natural
--- key, so only the other four languages need columns. They are nullable
--- because a category added later should not be blocked on having every
--- translation ready; the API falls back rather than showing nothing.
+-- key, so only the other four languages need columns. They are nullable because
+-- a category added later should not be blocked on having every translation
+-- ready; the API falls back rather than refusing to show anything.
 --
--- Seed values are the labels the web frontend already shipped, moved here so
--- the taxonomy and its display text live together. They are authored
--- translations, not generated ones — including the Romansh, which is why they
--- are worth migrating rather than regenerating.
+-- Schema only, no data. The 13 category rows are inserted by
+-- scripts/seed_products.py, which runs AFTER migrations — so seeding the labels
+-- here would have updated an empty table on every fresh database and left the
+-- columns null in CI and on any new environment. The seeder owns this content
+-- and now writes the labels with it.
 ALTER TABLE product_categories
     ADD COLUMN name_en text,
     ADD COLUMN name_fr text,
     ADD COLUMN name_it text,
     ADD COLUMN name_rm text;
-
-UPDATE product_categories SET name_en = 'Fruits', name_fr = 'Fruits', name_it = 'Frutta', name_rm = 'Fritgs' WHERE slug = 'fruits';
-UPDATE product_categories SET name_en = 'Vegetables', name_fr = 'Légumes', name_it = 'Verdura', name_rm = 'Verduras' WHERE slug = 'vegetables';
-UPDATE product_categories SET name_en = 'Dairy', name_fr = 'Produits laitiers', name_it = 'Latticini', name_rm = 'Products da latg' WHERE slug = 'dairy';
-UPDATE product_categories SET name_en = 'Meat & poultry', name_fr = 'Viande et volaille', name_it = 'Carne e pollame', name_rm = 'Charn e pulam' WHERE slug = 'meat-poultry';
-UPDATE product_categories SET name_en = 'Preserves & processed', name_fr = 'Produits transformés et conserves', name_it = 'Prodotti trasformati e conserve', name_rm = 'Products transformads e conservads' WHERE slug = 'preserves';
-UPDATE product_categories SET name_en = 'Honey & sweeteners', name_fr = 'Miel et édulcorants', name_it = 'Miele e dolcificanti', name_rm = 'Mel e dultschadiras' WHERE slug = 'honey-sweeteners';
-UPDATE product_categories SET name_en = 'Drinks', name_fr = 'Boissons', name_it = 'Bevande', name_rm = 'Bavrondas' WHERE slug = 'drinks';
-UPDATE product_categories SET name_en = 'Bakery', name_fr = 'Boulangerie', name_it = 'Prodotti da forno', name_rm = 'Ar da furnaria' WHERE slug = 'bakery';
-UPDATE product_categories SET name_en = 'Flowers & plants', name_fr = 'Fleurs et plantes', name_it = 'Fiori e piante', name_rm = 'Flurs e plantas' WHERE slug = 'flowers-plants';
-UPDATE product_categories SET name_en = 'Nuts, seeds & oils', name_fr = 'Noix, graines et huiles', name_it = 'Noci, semi e oli', name_rm = 'Nuschs, sems ed ieli' WHERE slug = 'nuts-oils';
-UPDATE product_categories SET name_en = 'Grains & cereals', name_fr = 'Céréales', name_it = 'Cereali', name_rm = 'Cereals' WHERE slug = 'grains';
-UPDATE product_categories SET name_en = 'Fish & seafood', name_fr = 'Poisson et fruits de mer', name_it = 'Pesce e frutti di mare', name_rm = 'Pesch e fritgs da mar' WHERE slug = 'fish-seafood';
-UPDATE product_categories SET name_en = 'Other', name_fr = 'Autres', name_it = 'Altro', name_rm = 'Auter' WHERE slug = 'other';

--- a/migrations/20260801165616_add_category_localised_labels.sql
+++ b/migrations/20260801165616_add_category_localised_labels.sql
@@ -1,0 +1,30 @@
+-- Localised display labels for the category groups.
+--
+-- `key_de` already holds the canonical German label and doubles as the natural
+-- key, so only the other four languages need columns. They are nullable
+-- because a category added later should not be blocked on having every
+-- translation ready; the API falls back rather than showing nothing.
+--
+-- Seed values are the labels the web frontend already shipped, moved here so
+-- the taxonomy and its display text live together. They are authored
+-- translations, not generated ones — including the Romansh, which is why they
+-- are worth migrating rather than regenerating.
+ALTER TABLE product_categories
+    ADD COLUMN name_en text,
+    ADD COLUMN name_fr text,
+    ADD COLUMN name_it text,
+    ADD COLUMN name_rm text;
+
+UPDATE product_categories SET name_en = 'Fruits', name_fr = 'Fruits', name_it = 'Frutta', name_rm = 'Fritgs' WHERE slug = 'fruits';
+UPDATE product_categories SET name_en = 'Vegetables', name_fr = 'Légumes', name_it = 'Verdura', name_rm = 'Verduras' WHERE slug = 'vegetables';
+UPDATE product_categories SET name_en = 'Dairy', name_fr = 'Produits laitiers', name_it = 'Latticini', name_rm = 'Products da latg' WHERE slug = 'dairy';
+UPDATE product_categories SET name_en = 'Meat & poultry', name_fr = 'Viande et volaille', name_it = 'Carne e pollame', name_rm = 'Charn e pulam' WHERE slug = 'meat-poultry';
+UPDATE product_categories SET name_en = 'Preserves & processed', name_fr = 'Produits transformés et conserves', name_it = 'Prodotti trasformati e conserve', name_rm = 'Products transformads e conservads' WHERE slug = 'preserves';
+UPDATE product_categories SET name_en = 'Honey & sweeteners', name_fr = 'Miel et édulcorants', name_it = 'Miele e dolcificanti', name_rm = 'Mel e dultschadiras' WHERE slug = 'honey-sweeteners';
+UPDATE product_categories SET name_en = 'Drinks', name_fr = 'Boissons', name_it = 'Bevande', name_rm = 'Bavrondas' WHERE slug = 'drinks';
+UPDATE product_categories SET name_en = 'Bakery', name_fr = 'Boulangerie', name_it = 'Prodotti da forno', name_rm = 'Ar da furnaria' WHERE slug = 'bakery';
+UPDATE product_categories SET name_en = 'Flowers & plants', name_fr = 'Fleurs et plantes', name_it = 'Fiori e piante', name_rm = 'Flurs e plantas' WHERE slug = 'flowers-plants';
+UPDATE product_categories SET name_en = 'Nuts, seeds & oils', name_fr = 'Noix, graines et huiles', name_it = 'Noci, semi e oli', name_rm = 'Nuschs, sems ed ieli' WHERE slug = 'nuts-oils';
+UPDATE product_categories SET name_en = 'Grains & cereals', name_fr = 'Céréales', name_it = 'Cereali', name_rm = 'Cereals' WHERE slug = 'grains';
+UPDATE product_categories SET name_en = 'Fish & seafood', name_fr = 'Poisson et fruits de mer', name_it = 'Pesce e frutti di mare', name_rm = 'Pesch e fritgs da mar' WHERE slug = 'fish-seafood';
+UPDATE product_categories SET name_en = 'Other', name_fr = 'Autres', name_it = 'Altro', name_rm = 'Auter' WHERE slug = 'other';

--- a/scripts/seed_products.py
+++ b/scripts/seed_products.py
@@ -43,24 +43,32 @@ DATA_PATH = os.path.join(
 FARM_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_URL, "https://farms.app/seed")
 SEED_CREATED_AT = "2026-06-01T00:00:00Z"
 
-# The 13 canonical groups: German key (the dataset's key) -> (English, slug).
-# Slugs are the stable public identity the frontend keys its display on.
+# The 13 canonical groups, with their display labels.
+#
+# (German key, English, slug, French, Italian, Romansh). The German key is the
+# dataset's own key and doubles as the canonical German label; the slug is the
+# stable public identity that filtering and the frontend key on.
+#
+# The fr/it/rm labels are authored translations carried over from the web
+# frontend, which held them before the API did. They live here because this
+# script owns the taxonomy's content — a migration cannot seed them, since
+# migrations run before this does and would update an empty table.
 GROUPS = [
-    ("Früchte", "Fruits", "fruits"),
-    ("Gemüse", "Vegetables", "vegetables"),
-    ("Milchprodukte", "Dairy", "dairy"),
-    ("Fleisch und Geflügel", "Meat & poultry", "meat-poultry"),
-    ("Verarbeitete und haltbare Produkte", "Preserves & processed", "preserves"),
-    ("Honig und Süßstoffe", "Honey & sweeteners", "honey-sweeteners"),
-    ("Getränke", "Drinks", "drinks"),
-    ("Backwaren und Gebäck", "Bakery", "bakery"),
-    ("Blumen und Pflanzen", "Flowers & plants", "flowers-plants"),
-    ("Nüsse, Samen und Öle", "Nuts, seeds & oils", "nuts-oils"),
-    ("Getreide und Cerealien", "Grains & cereals", "grains"),
-    ("Fisch und Meeresfrüchte", "Fish & seafood", "fish-seafood"),
-    ("Sonstiges", "Other", "other"),
+    ('Früchte', 'Fruits', 'fruits', 'Fruits', 'Frutta', 'Fritgs'),
+    ('Gemüse', 'Vegetables', 'vegetables', 'Légumes', 'Verdura', 'Verduras'),
+    ('Milchprodukte', 'Dairy', 'dairy', 'Produits laitiers', 'Latticini', 'Products da latg'),
+    ('Fleisch und Geflügel', 'Meat & poultry', 'meat-poultry', 'Viande et volaille', 'Carne e pollame', 'Charn e pulam'),
+    ('Verarbeitete und haltbare Produkte', 'Preserves & processed', 'preserves', 'Produits transformés et conserves', 'Prodotti trasformati e conserve', 'Products transformads e conservads'),
+    ('Honig und Süßstoffe', 'Honey & sweeteners', 'honey-sweeteners', 'Miel et édulcorants', 'Miele e dolcificanti', 'Mel e dultschadiras'),
+    ('Getränke', 'Drinks', 'drinks', 'Boissons', 'Bevande', 'Bavrondas'),
+    ('Backwaren und Gebäck', 'Bakery', 'bakery', 'Boulangerie', 'Prodotti da forno', 'Ar da furnaria'),
+    ('Blumen und Pflanzen', 'Flowers & plants', 'flowers-plants', 'Fleurs et plantes', 'Fiori e piante', 'Flurs e plantas'),
+    ('Nüsse, Samen und Öle', 'Nuts, seeds & oils', 'nuts-oils', 'Noix, graines et huiles', 'Noci, semi e oli', 'Nuschs, sems ed ieli'),
+    ('Getreide und Cerealien', 'Grains & cereals', 'grains', 'Céréales', 'Cereali', 'Cereals'),
+    ('Fisch und Meeresfrüchte', 'Fish & seafood', 'fish-seafood', 'Poisson et fruits de mer', 'Pesce e frutti di mare', 'Pesch e fritgs da mar'),
+    ('Sonstiges', 'Other', 'other', 'Autres', 'Altro', 'Auter'),
 ]
-GROUP_SLUG_BY_DE = {de: slug for de, _en, slug in GROUPS}
+GROUP_SLUG_BY_DE = {row[0]: row[2] for row in GROUPS}
 
 VALID_CANTONS = {
     "AG", "AI", "AR", "BE", "BL", "BS", "FR", "GE", "GL", "GR", "JU", "LU",
@@ -217,14 +225,18 @@ def main() -> int:
 
         out("-- Category groups.\n")
         cat_values = ",\n  ".join(
-            f"({sql_str(de)}, {sql_str(slug)}, {i})"
-            for i, (de, _en, slug) in enumerate(GROUPS)
+            f"({sql_str(de)}, {sql_str(slug)}, {i}, {sql_str(en)}, "
+            f"{sql_str(fr)}, {sql_str(it)}, {sql_str(rm)})"
+            for i, (de, en, slug, fr, it, rm) in enumerate(GROUPS)
         )
         out(
-            "INSERT INTO product_categories (key_de, slug, display_order)\n"
+            "INSERT INTO product_categories\n"
+            "  (key_de, slug, display_order, name_en, name_fr, name_it, name_rm)\n"
             f"VALUES\n  {cat_values}\n"
             "ON CONFLICT (key_de) DO UPDATE\n"
-            "  SET slug = EXCLUDED.slug, display_order = EXCLUDED.display_order;\n\n"
+            "  SET slug = EXCLUDED.slug, display_order = EXCLUDED.display_order,\n"
+            "      name_en = EXCLUDED.name_en, name_fr = EXCLUDED.name_fr,\n"
+            "      name_it = EXCLUDED.name_it, name_rm = EXCLUDED.name_rm;\n\n"
         )
 
         out(f"-- Products ({len(products)} granular).\n")

--- a/src/domain/language.rs
+++ b/src/domain/language.rs
@@ -31,7 +31,13 @@ pub enum Language {
 
 #[derive(Debug, thiserror::Error)]
 pub enum LanguageError {
-    #[error("Unsupported language '{0}'. Supported languages are: en, de, fr, it, rm.")]
+    // Generated from `ALL` rather than spelled out, so the message cannot drift
+    // from the set actually accepted. A hardcoded list would still compile, and
+    // still read plausibly, after a language was added.
+    #[error(
+        "Unsupported language '{0}'. Supported languages are: {codes}.",
+        codes = Language::ALL.map(|language| language.code()).join(", ")
+    )]
     Unsupported(String),
 }
 
@@ -152,7 +158,15 @@ mod tests {
         // so a caller can fix the request without reading the source.
         let message = error.to_string();
         assert!(message.contains("es"), "got: {message}");
-        assert!(message.contains("en, de, fr, it, rm"), "got: {message}");
+        // Checked against ALL rather than a frozen "en, de, fr, it, rm": a
+        // literal here would keep passing after a sixth language was added,
+        // while the message quietly told callers it was unsupported.
+        for language in Language::ALL {
+            assert!(
+                message.contains(language.code()),
+                "{language} is supported but missing from: {message}"
+            );
+        }
     }
 
     #[test]

--- a/src/domain/language.rs
+++ b/src/domain/language.rs
@@ -1,0 +1,205 @@
+//! Supported API languages.
+//!
+//! The API separates *stable keys* from *display labels*: filtering always uses
+//! language-independent slugs, while the language selected here only decides
+//! which human-readable label is returned. That split is what lets a caller ask
+//! for `?category=vegetables&lang=de` and get German text back without the
+//! filter itself becoming language-dependent.
+//!
+//! Switzerland has four national languages, and the platform additionally
+//! serves English, so five codes are supported.
+
+use std::fmt::Display;
+use std::str::FromStr;
+
+/// A language the API can return display labels in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Language {
+    /// English — also the fallback when a translation is missing.
+    #[default]
+    En,
+    /// German (Deutsch).
+    De,
+    /// French (français).
+    Fr,
+    /// Italian (italiano).
+    It,
+    /// Romansh (rumantsch).
+    Rm,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum LanguageError {
+    #[error("Unsupported language '{0}'. Supported languages are: en, de, fr, it, rm.")]
+    Unsupported(String),
+}
+
+impl Language {
+    /// Every supported language, in a stable order suitable for documentation
+    /// and for building an "available languages" response.
+    pub const ALL: [Language; 5] = [
+        Language::En,
+        Language::De,
+        Language::Fr,
+        Language::It,
+        Language::Rm,
+    ];
+
+    /// The two-letter code, as accepted by `?lang=` and returned in responses.
+    pub fn code(self) -> &'static str {
+        match self {
+            Language::En => "en",
+            Language::De => "de",
+            Language::Fr => "fr",
+            Language::It => "it",
+            Language::Rm => "rm",
+        }
+    }
+
+    /// Parse a language tag.
+    ///
+    /// Accepts a bare code (`de`) or a regional tag (`de-CH`, `de_CH`), because
+    /// browsers and mobile clients routinely send the regional form and every
+    /// Swiss regional variant maps onto the same label set we hold. Matching is
+    /// case-insensitive: `DE`, `de` and `de-CH` are the same request.
+    pub fn parse(value: &str) -> Result<Self, LanguageError> {
+        let trimmed = value.trim();
+        // Take the primary subtag: "de-CH" and "de_CH" both mean German here.
+        let primary = trimmed
+            .split(['-', '_'])
+            .next()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+
+        match primary.as_str() {
+            "en" => Ok(Language::En),
+            "de" => Ok(Language::De),
+            "fr" => Ok(Language::Fr),
+            "it" => Ok(Language::It),
+            "rm" => Ok(Language::Rm),
+            // Report the caller's original input, not the normalised primary
+            // subtag, so the message names what they actually sent.
+            _ => Err(LanguageError::Unsupported(trimmed.to_string())),
+        }
+    }
+
+    /// Resolve an optional `?lang=` value, defaulting when it is absent.
+    ///
+    /// An absent language is not an error — it selects the default. An
+    /// unsupported one is, matching how unknown category and product slugs are
+    /// rejected rather than silently ignored: a caller who asked for something
+    /// specific should hear that they did not get it.
+    pub fn from_query(value: Option<&str>) -> Result<Self, LanguageError> {
+        match value {
+            None => Ok(Language::default()),
+            // `?lang=` with no value reads as "unset" rather than as a typo.
+            Some(raw) if raw.trim().is_empty() => Ok(Language::default()),
+            Some(raw) => Language::parse(raw),
+        }
+    }
+}
+
+impl Display for Language {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.code())
+    }
+}
+
+impl FromStr for Language {
+    type Err = LanguageError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Language::parse(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_every_supported_code() {
+        for language in Language::ALL {
+            assert_eq!(Language::parse(language.code()).unwrap(), language);
+        }
+    }
+
+    #[test]
+    fn parsing_is_case_insensitive() {
+        assert_eq!(Language::parse("DE").unwrap(), Language::De);
+        assert_eq!(Language::parse("Rm").unwrap(), Language::Rm);
+    }
+
+    #[test]
+    fn accepts_regional_tags() {
+        // Swiss clients commonly send these; they all want the same labels.
+        for tag in ["de-CH", "de_CH", "fr-CH", "it-CH", "rm-CH", "en-GB"] {
+            assert!(Language::parse(tag).is_ok(), "expected {tag} to parse");
+        }
+        assert_eq!(Language::parse("de-CH").unwrap(), Language::De);
+    }
+
+    #[test]
+    fn ignores_surrounding_whitespace() {
+        assert_eq!(Language::parse("  fr  ").unwrap(), Language::Fr);
+    }
+
+    #[test]
+    fn rejects_an_unsupported_language() {
+        let error = Language::parse("es").unwrap_err();
+        // The message must name the offending input and list what is allowed,
+        // so a caller can fix the request without reading the source.
+        let message = error.to_string();
+        assert!(message.contains("es"), "got: {message}");
+        assert!(message.contains("en, de, fr, it, rm"), "got: {message}");
+    }
+
+    #[test]
+    fn reports_the_original_input_not_the_primary_subtag() {
+        let message = Language::parse("es-AR").unwrap_err().to_string();
+        assert!(message.contains("es-AR"), "got: {message}");
+    }
+
+    #[test]
+    fn rejects_nonsense_that_merely_starts_with_a_valid_code() {
+        // "den" must not be accepted as German: only a subtag boundary counts.
+        assert!(Language::parse("den").is_err());
+        assert!(Language::parse("english").is_err());
+    }
+
+    #[test]
+    fn english_is_the_default() {
+        assert_eq!(Language::default(), Language::En);
+        assert_eq!(Language::from_query(None).unwrap(), Language::En);
+    }
+
+    #[test]
+    fn an_empty_lang_parameter_selects_the_default() {
+        assert_eq!(Language::from_query(Some("")).unwrap(), Language::En);
+        assert_eq!(Language::from_query(Some("   ")).unwrap(), Language::En);
+    }
+
+    #[test]
+    fn from_query_rejects_an_unsupported_value() {
+        assert!(Language::from_query(Some("es")).is_err());
+    }
+
+    #[test]
+    fn serializes_as_its_lowercase_code() {
+        let json = serde_json::to_string(&Language::De).unwrap();
+        assert_eq!(json, "\"de\"");
+    }
+
+    #[test]
+    fn displays_as_its_code() {
+        assert_eq!(Language::De.to_string(), "de");
+        assert_eq!(Language::Rm.to_string(), "rm");
+    }
+
+    #[test]
+    fn from_str_matches_parse() {
+        let via_from_str: Language = "it".parse().unwrap();
+        assert_eq!(via_from_str, Language::parse("it").unwrap());
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -6,5 +6,6 @@ pub mod test_data;
 
 // Domain entities
 pub mod farm;
+pub mod language;
 pub mod suggestion;
 pub mod user;

--- a/src/routes/farms/get.rs
+++ b/src/routes/farms/get.rs
@@ -1,5 +1,6 @@
 use crate::{
     domain::farm::{Address, Canton, Name, Point, StockStatus},
+    domain::language::Language,
     routes::farms::{FarmError, FarmListResponse, FarmResponse, FarmRow, ProductDto},
     taxonomy::TaxonomySnapshot,
 };
@@ -8,6 +9,13 @@ use anyhow::Context;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use uuid::Uuid;
+
+/// Query parameters accepted by `GET /farms/{id}`.
+#[derive(Debug, serde::Deserialize)]
+pub struct FarmDetailQuery {
+    /// Display language for labels — see `FarmListQuery::lang`.
+    pub lang: Option<String>,
+}
 
 #[derive(Debug, serde::Deserialize)]
 pub struct FarmPath {
@@ -35,6 +43,9 @@ pub struct FarmListQuery {
     pub radius_km: Option<f64>,
     /// `newest` (default) | `name` | `canton` | `nearest` (needs lat/lng).
     pub sort: Option<String>,
+    /// Display language for labels: `en` (default) | `de` | `fr` | `it` | `rm`.
+    /// Filtering is unaffected — slugs stay language-independent.
+    pub lang: Option<String>,
     #[serde(default = "default_limit")]
     pub limit: i64,
     #[serde(default)]
@@ -65,6 +76,10 @@ pub async fn get_all(
 ) -> Result<HttpResponse, FarmError> {
     let limit = query.limit.clamp(1, 100);
     let offset = query.offset.max(0);
+    // Resolve the display language up front so an unsupported code fails the
+    // request before any database work, the same way unknown slugs do.
+    let language = Language::from_query(query.lang.as_deref())
+        .map_err(|e| FarmError::ValidationError(e.to_string()))?;
     let sort = query.sort.as_deref().unwrap_or("newest");
 
     // Resolve product slugs to ids (early 400 on any unknown slug).
@@ -128,7 +143,11 @@ pub async fn get_all(
         None
     };
 
-    Ok(HttpResponse::Ok().json(FarmListResponse { farms, next_cursor }))
+    Ok(HttpResponse::Ok().json(FarmListResponse {
+        farms,
+        next_cursor,
+        lang: language,
+    }))
 }
 
 /// Resolve a comma-separated slug list to ids via `resolver`, 400 on unknown.
@@ -354,8 +373,14 @@ async fn load_products(
 #[tracing::instrument(name = "Get farm by id", skip(pool))]
 pub async fn get_by_id(
     path: web::Path<FarmPath>,
+    query: web::Query<FarmDetailQuery>,
     pool: web::Data<PgPool>,
 ) -> Result<HttpResponse, FarmError> {
+    // Validate the language even though the detail response does not vary by it
+    // yet: rejecting `?lang=es` consistently on both endpoints means clients
+    // learn the contract from either one, and the labels land in #128/#129.
+    let _language = Language::from_query(query.lang.as_deref())
+        .map_err(|e| FarmError::ValidationError(e.to_string()))?;
     let farm_id = Uuid::parse_str(&path.id)
         .map_err(|_| FarmError::ValidationError("Invalid farm id.".to_string()))?;
 

--- a/src/routes/farms/get.rs
+++ b/src/routes/farms/get.rs
@@ -1,7 +1,9 @@
 use crate::{
     domain::farm::{Address, Canton, Name, Point, StockStatus},
     domain::language::Language,
-    routes::farms::{FarmError, FarmListResponse, FarmResponse, FarmRow, ProductDto},
+    routes::farms::{
+        FarmDetailResponse, FarmError, FarmListResponse, FarmResponse, FarmRow, ProductDto,
+    },
     taxonomy::TaxonomySnapshot,
 };
 use actix_web::{HttpResponse, web};
@@ -376,16 +378,16 @@ pub async fn get_by_id(
     query: web::Query<FarmDetailQuery>,
     pool: web::Data<PgPool>,
 ) -> Result<HttpResponse, FarmError> {
-    // Validate the language even though the detail response does not vary by it
-    // yet: rejecting `?lang=es` consistently on both endpoints means clients
-    // learn the contract from either one, and the labels land in #128/#129.
-    let _language = Language::from_query(query.lang.as_deref())
+    let language = Language::from_query(query.lang.as_deref())
         .map_err(|e| FarmError::ValidationError(e.to_string()))?;
     let farm_id = Uuid::parse_str(&path.id)
         .map_err(|_| FarmError::ValidationError("Invalid farm id.".to_string()))?;
 
     match get_farm_by_id(farm_id, &pool).await? {
-        Some(farm) => Ok(HttpResponse::Ok().json(farm)),
+        Some(farm) => Ok(HttpResponse::Ok().json(FarmDetailResponse {
+            farm,
+            lang: language,
+        })),
         None => Err(FarmError::NotFound),
     }
 }

--- a/src/routes/farms/mod.rs
+++ b/src/routes/farms/mod.rs
@@ -46,6 +46,23 @@ pub struct FarmResponse {
     pub updated_at: Option<DateTime<Utc>>,
 }
 
+/// A single farm plus the language it was resolved for.
+///
+/// The list endpoint echoes `lang` at the top level, and the detail endpoint
+/// has to as well — a client should be able to read the same field from either
+/// without a special case. Flattened, so every existing field stays exactly
+/// where it was and adding this moves nothing a caller already reads.
+///
+/// It lives here rather than on `FarmResponse` because that type is also the
+/// element type of the list, where repeating the language on all hundred farms
+/// would say the same thing a hundred times.
+#[derive(serde::Serialize)]
+pub struct FarmDetailResponse {
+    #[serde(flatten)]
+    pub farm: FarmResponse,
+    pub lang: Language,
+}
+
 /// A page of farms plus the offset to fetch the next page (if any).
 #[derive(serde::Serialize)]
 pub struct FarmListResponse {

--- a/src/routes/farms/mod.rs
+++ b/src/routes/farms/mod.rs
@@ -1,4 +1,5 @@
 use crate::domain::farm::{Address, Canton, Name, Point, StockStatus};
+use crate::domain::language::Language;
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
@@ -51,6 +52,13 @@ pub struct FarmListResponse {
     pub farms: Vec<FarmResponse>,
     /// Offset for the next page as a string, or null when this is the last page.
     pub next_cursor: Option<String>,
+    /// The language the labels in this response were resolved to.
+    ///
+    /// Echoing it back means a caller can tell the difference between "you got
+    /// German because you asked" and "you got the default", without having to
+    /// infer it from the payload. It is also what makes an omitted `lang`
+    /// self-documenting.
+    pub lang: Language,
 }
 
 /// The raw farm row loaded from the database, before products are attached.

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -3,5 +3,6 @@ pub mod authentication;
 pub mod farms;
 mod health_check;
 pub mod suggestions;
+pub mod taxonomy;
 
 pub use health_check::*;

--- a/src/routes/taxonomy/get.rs
+++ b/src/routes/taxonomy/get.rs
@@ -1,0 +1,70 @@
+use crate::{domain::language::Language, routes::farms::FarmError, taxonomy::TaxonomySnapshot};
+use actix_web::{HttpResponse, web};
+
+/// Query parameters for `GET /taxonomy`.
+#[derive(Debug, serde::Deserialize)]
+pub struct TaxonomyQuery {
+    /// Display language for the labels — see `FarmListQuery::lang`.
+    pub lang: Option<String>,
+}
+
+/// A category group as returned to API clients.
+#[derive(serde::Serialize)]
+pub struct CategoryDto {
+    /// Stable, language-independent identifier. This is what `?category=`
+    /// takes, and what a client should store.
+    pub slug: String,
+    /// Display label in the requested language, falling back where a
+    /// translation is missing.
+    pub name: String,
+    /// Whether `name` is a real translation or a fallback. Lets a client decide
+    /// whether to show the label as authoritative, and lets us measure coverage
+    /// without guessing.
+    pub translated: bool,
+}
+
+/// The vocabulary the API filters on, with display labels.
+#[derive(serde::Serialize)]
+pub struct TaxonomyResponse {
+    /// The language the labels were resolved to.
+    pub lang: Language,
+    pub categories: Vec<CategoryDto>,
+}
+
+/// `GET /taxonomy` — the whole filtering vocabulary in one request.
+///
+/// This exists so a client does not have to carry its own copy of the taxonomy.
+/// Anything with a picker, a type-ahead, or an offline mode needs the *full*
+/// list of categories, not just the ones attached to the farms in the current
+/// response — so putting labels on `/farms` alone would leave every client
+/// maintaining a duplicate list and keeping it in sync by hand.
+///
+/// Labels are deliberately absent from `/farms`: repeating thirteen category
+/// strings across three thousand farms would be a lot of bytes to say something
+/// a client can look up once and cache.
+///
+/// The response is small (tens of rows) and changes only on deploy, so it is a
+/// good candidate for a long client-side cache.
+#[tracing::instrument(name = "Get taxonomy", skip(taxonomy))]
+pub async fn get_taxonomy(
+    query: web::Query<TaxonomyQuery>,
+    taxonomy: web::Data<TaxonomySnapshot>,
+) -> Result<HttpResponse, FarmError> {
+    let language = Language::from_query(query.lang.as_deref())
+        .map_err(|e| FarmError::ValidationError(e.to_string()))?;
+
+    let categories = taxonomy
+        .categories()
+        .iter()
+        .map(|category| CategoryDto {
+            slug: category.slug.clone(),
+            name: category.labels.resolve(language).to_string(),
+            translated: category.labels.has(language),
+        })
+        .collect();
+
+    Ok(HttpResponse::Ok().json(TaxonomyResponse {
+        lang: language,
+        categories,
+    }))
+}

--- a/src/routes/taxonomy/get.rs
+++ b/src/routes/taxonomy/get.rs
@@ -1,5 +1,5 @@
 use crate::{domain::language::Language, routes::farms::FarmError, taxonomy::TaxonomySnapshot};
-use actix_web::{HttpResponse, web};
+use actix_web::{HttpResponse, http::header, web};
 
 /// Query parameters for `GET /taxonomy`.
 #[derive(Debug, serde::Deserialize)]
@@ -31,6 +31,19 @@ pub struct TaxonomyResponse {
     pub categories: Vec<CategoryDto>,
 }
 
+/// How long a client may reuse this response.
+///
+/// The served vocabulary is a snapshot taken at startup, so it cannot change
+/// until the app is redeployed — an hour of caching risks nothing that a
+/// restart would not already have to wait for. `stale-while-revalidate` lets a
+/// picker render instantly from a day-old copy while the refresh happens in the
+/// background, which matters because this is on the critical path for anything
+/// with a type-ahead.
+///
+/// `public`: the response depends only on `?lang=`, which is in the URL, so a
+/// shared cache can serve it to everyone. No session, no `Vary` needed.
+const CACHE_CONTROL: &str = "public, max-age=3600, stale-while-revalidate=86400";
+
 /// `GET /taxonomy` — the whole filtering vocabulary in one request.
 ///
 /// This exists so a client does not have to carry its own copy of the taxonomy.
@@ -43,8 +56,9 @@ pub struct TaxonomyResponse {
 /// strings across three thousand farms would be a lot of bytes to say something
 /// a client can look up once and cache.
 ///
-/// The response is small (tens of rows) and changes only on deploy, so it is a
-/// good candidate for a long client-side cache.
+/// The response is small (tens of rows) and only changes when the taxonomy is
+/// reseeded and the app restarted, so it is served with a long cache lifetime —
+/// see `CACHE_CONTROL` above.
 #[tracing::instrument(name = "Get taxonomy", skip(taxonomy))]
 pub async fn get_taxonomy(
     query: web::Query<TaxonomyQuery>,
@@ -63,8 +77,10 @@ pub async fn get_taxonomy(
         })
         .collect();
 
-    Ok(HttpResponse::Ok().json(TaxonomyResponse {
-        lang: language,
-        categories,
-    }))
+    Ok(HttpResponse::Ok()
+        .insert_header((header::CACHE_CONTROL, CACHE_CONTROL))
+        .json(TaxonomyResponse {
+            lang: language,
+            categories,
+        }))
 }

--- a/src/routes/taxonomy/mod.rs
+++ b/src/routes/taxonomy/mod.rs
@@ -1,0 +1,3 @@
+mod get;
+
+pub use get::get_taxonomy;

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -2,7 +2,7 @@ use crate::configuration::{
     DatabaseSettings, RedisSettings, SessionSameSite, SessionSettings, Settings,
 };
 use crate::email_client::EmailClient;
-use crate::routes::{admin, authentication, farms, health_check, suggestions};
+use crate::routes::{admin, authentication, farms, health_check, suggestions, taxonomy};
 use actix_session::{
     SessionMiddleware,
     config::{CookieContentSecurity, PersistentSession, TtlExtensionPolicy},
@@ -185,6 +185,7 @@ pub async fn run(
             .route("/farms", web::post().to(farms::create))
             .route("/farms", web::get().to(farms::get_all))
             .route("/farms/{id}", web::get().to(farms::get_by_id))
+            .route("/taxonomy", web::get().to(taxonomy::get_taxonomy))
             .route(
                 "/farms/{id}/product-suggestions",
                 web::post().to(suggestions::submit_suggestion),

--- a/src/taxonomy/labels.rs
+++ b/src/taxonomy/labels.rs
@@ -1,0 +1,159 @@
+//! Display labels for taxonomy entries, in a requested language.
+//!
+//! Every taxonomy row carries a canonical German label (`key_de`, which also
+//! serves as its natural key) plus optional columns for the other languages.
+//! Translations are added over time, so a lookup has to cope with the requested
+//! one being absent.
+
+use crate::domain::language::Language;
+
+/// The labels a taxonomy row holds, one slot per supported language.
+///
+/// German is not optional: it is the canonical label and doubles as the row's
+/// natural key, so it is always present and always available as a last resort.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LocalisedLabels {
+    pub de: String,
+    pub en: Option<String>,
+    pub fr: Option<String>,
+    pub it: Option<String>,
+    pub rm: Option<String>,
+}
+
+impl LocalisedLabels {
+    /// The label in `language`, or the closest available substitute.
+    ///
+    /// Order: the requested language, then English, then German.
+    ///
+    /// English sits in the middle rather than German because it is the wider
+    /// second language of the two for this audience — a French or Italian
+    /// speaker without a translation is much more likely to read "Pineapple"
+    /// than "Ananas" as intended, and Romansh speakers are all fluent in German
+    /// anyway, so nobody is left without something readable.
+    ///
+    /// The chain never yields an empty string: German is non-optional, so the
+    /// caller always gets a real label and never has to invent a placeholder.
+    pub fn resolve(&self, language: Language) -> &str {
+        let requested = match language {
+            Language::De => return &self.de,
+            Language::En => self.en.as_deref(),
+            Language::Fr => self.fr.as_deref(),
+            Language::It => self.it.as_deref(),
+            Language::Rm => self.rm.as_deref(),
+        };
+
+        requested.or(self.en.as_deref()).unwrap_or(&self.de)
+    }
+
+    /// Whether `language` has its own translation, as opposed to being served a
+    /// fallback. Lets callers report coverage without re-deriving the chain.
+    pub fn has(&self, language: Language) -> bool {
+        match language {
+            Language::De => true,
+            Language::En => self.en.is_some(),
+            Language::Fr => self.fr.is_some(),
+            Language::It => self.it.is_some(),
+            Language::Rm => self.rm.is_some(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn full() -> LocalisedLabels {
+        LocalisedLabels {
+            de: "Gemüse".into(),
+            en: Some("Vegetables".into()),
+            fr: Some("Légumes".into()),
+            it: Some("Verdura".into()),
+            rm: Some("Verduras".into()),
+        }
+    }
+
+    /// German only — the state every product is in until #162 is done.
+    fn german_and_english_only() -> LocalisedLabels {
+        LocalisedLabels {
+            de: "Ananas".into(),
+            en: Some("Pineapple".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn returns_the_requested_language_when_present() {
+        let labels = full();
+        assert_eq!(labels.resolve(Language::De), "Gemüse");
+        assert_eq!(labels.resolve(Language::En), "Vegetables");
+        assert_eq!(labels.resolve(Language::Fr), "Légumes");
+        assert_eq!(labels.resolve(Language::It), "Verdura");
+        assert_eq!(labels.resolve(Language::Rm), "Verduras");
+    }
+
+    #[test]
+    fn falls_back_to_english_when_the_translation_is_missing() {
+        let labels = german_and_english_only();
+        for language in [Language::Fr, Language::It, Language::Rm] {
+            assert_eq!(
+                labels.resolve(language),
+                "Pineapple",
+                "{language} should fall back to English"
+            );
+        }
+    }
+
+    #[test]
+    fn falls_back_to_german_when_english_is_missing_too() {
+        let labels = LocalisedLabels {
+            de: "Sonstiges".into(),
+            ..Default::default()
+        };
+        for language in Language::ALL {
+            assert_eq!(labels.resolve(language), "Sonstiges", "{language}");
+        }
+    }
+
+    #[test]
+    fn german_never_falls_back() {
+        // German is the canonical label, so asking for it must not consult the
+        // chain even when every other column is populated.
+        let labels = full();
+        assert_eq!(labels.resolve(Language::De), "Gemüse");
+    }
+
+    #[test]
+    fn resolve_never_returns_an_empty_string() {
+        // The point of German being non-optional: callers never have to invent
+        // a placeholder or render a blank chip.
+        let labels = LocalisedLabels {
+            de: "Auter".into(),
+            ..Default::default()
+        };
+        for language in Language::ALL {
+            assert!(!labels.resolve(language).is_empty());
+        }
+    }
+
+    #[test]
+    fn has_reports_real_translations_not_fallbacks() {
+        let labels = german_and_english_only();
+        assert!(labels.has(Language::De));
+        assert!(labels.has(Language::En));
+        // These resolve to English, but they are not translated.
+        assert!(!labels.has(Language::Fr));
+        assert!(!labels.has(Language::It));
+        assert!(!labels.has(Language::Rm));
+    }
+
+    #[test]
+    fn has_is_always_true_for_german() {
+        assert!(
+            LocalisedLabels {
+                de: "x".into(),
+                ..Default::default()
+            }
+            .has(Language::De)
+        );
+    }
+}

--- a/src/taxonomy/labels.rs
+++ b/src/taxonomy/labels.rs
@@ -20,6 +20,17 @@ pub struct LocalisedLabels {
     pub rm: Option<String>,
 }
 
+/// A column counts as a translation only when it holds something printable.
+///
+/// A blank cell is a missing translation wearing the costume of a present one:
+/// it would resolve to an empty label and be reported as `translated: true`.
+/// The database rejects blanks (see the migration adding these columns), but
+/// this type is also built by the seeder and by tests, so it enforces its own
+/// invariant rather than trusting a constraint it cannot see.
+fn present(value: &Option<String>) -> Option<&str> {
+    value.as_deref().filter(|text| !text.trim().is_empty())
+}
+
 impl LocalisedLabels {
     /// The label in `language`, or the closest available substitute.
     ///
@@ -36,13 +47,13 @@ impl LocalisedLabels {
     pub fn resolve(&self, language: Language) -> &str {
         let requested = match language {
             Language::De => return &self.de,
-            Language::En => self.en.as_deref(),
-            Language::Fr => self.fr.as_deref(),
-            Language::It => self.it.as_deref(),
-            Language::Rm => self.rm.as_deref(),
+            Language::En => present(&self.en),
+            Language::Fr => present(&self.fr),
+            Language::It => present(&self.it),
+            Language::Rm => present(&self.rm),
         };
 
-        requested.or(self.en.as_deref()).unwrap_or(&self.de)
+        requested.or(present(&self.en)).unwrap_or(&self.de)
     }
 
     /// Whether `language` has its own translation, as opposed to being served a
@@ -50,10 +61,10 @@ impl LocalisedLabels {
     pub fn has(&self, language: Language) -> bool {
         match language {
             Language::De => true,
-            Language::En => self.en.is_some(),
-            Language::Fr => self.fr.is_some(),
-            Language::It => self.it.is_some(),
-            Language::Rm => self.rm.is_some(),
+            Language::En => present(&self.en).is_some(),
+            Language::Fr => present(&self.fr).is_some(),
+            Language::It => present(&self.it).is_some(),
+            Language::Rm => present(&self.rm).is_some(),
         }
     }
 }
@@ -132,6 +143,66 @@ mod tests {
         };
         for language in Language::ALL {
             assert!(!labels.resolve(language).is_empty());
+        }
+    }
+
+    #[test]
+    fn a_blank_translation_counts_as_missing() {
+        // `text` admits '' and '   '. A blank column is a missing translation
+        // that merely looks present, and taking it would end the fallback chain
+        // on a label that renders as nothing at all.
+        let labels = LocalisedLabels {
+            de: "Beeren".into(),
+            en: Some("Berries".into()),
+            fr: Some(String::new()),
+            it: Some("   ".into()),
+            rm: Some("\t\n".into()),
+        };
+        for language in [Language::Fr, Language::It, Language::Rm] {
+            assert_eq!(
+                labels.resolve(language),
+                "Berries",
+                "{language} should skip its blank column and fall back"
+            );
+            assert!(!labels.has(language), "{language} is not translated");
+        }
+    }
+
+    #[test]
+    fn a_blank_english_column_does_not_break_the_chain() {
+        // English is both a requested language and the middle of the fallback
+        // chain, so a blank there has two chances to leak an empty label.
+        let labels = LocalisedLabels {
+            de: "Sonstiges".into(),
+            en: Some("  ".into()),
+            ..Default::default()
+        };
+        assert_eq!(labels.resolve(Language::En), "Sonstiges");
+        assert_eq!(labels.resolve(Language::Fr), "Sonstiges");
+        assert!(!labels.has(Language::En));
+    }
+
+    #[test]
+    fn no_arrangement_of_blanks_yields_an_empty_label() {
+        // The invariant `resolve` documents, checked against every combination
+        // of blank and absent rather than the one shape that first came to mind.
+        let blanks = [None, Some(String::new()), Some("   ".into())];
+        for en in &blanks {
+            for fr in &blanks {
+                let labels = LocalisedLabels {
+                    de: "Gemüse".into(),
+                    en: en.clone(),
+                    fr: fr.clone(),
+                    ..Default::default()
+                };
+                for language in Language::ALL {
+                    assert_eq!(
+                        labels.resolve(language),
+                        "Gemüse",
+                        "en={en:?} fr={fr:?} {language}"
+                    );
+                }
+            }
         }
     }
 

--- a/src/taxonomy/mod.rs
+++ b/src/taxonomy/mod.rs
@@ -32,6 +32,17 @@ pub struct TaxonomySnapshot {
     /// Category (group) slug -> id, for validating category filters and
     /// resolving group-level farm associations.
     category_by_slug: HashMap<String, i16>,
+    /// Every category group, in display order, with its labels. Held in memory
+    /// because it is thirteen rows that change only on deploy, and serving
+    /// /taxonomy from a snapshot avoids a query per request.
+    categories: Vec<CategoryInfo>,
+}
+
+/// A category group and the labels it can be displayed with.
+#[derive(Clone, Debug)]
+pub struct CategoryInfo {
+    pub slug: String,
+    pub labels: LocalisedLabels,
 }
 
 impl TaxonomySnapshot {
@@ -65,19 +76,42 @@ impl TaxonomySnapshot {
             by_id.insert(row.id, info);
         }
 
-        let category_rows = sqlx::query!(r#"SELECT id, slug FROM product_categories"#)
-            .fetch_all(pool)
-            .await?;
+        let category_rows = sqlx::query!(
+            r#"
+            SELECT id, slug, key_de, name_en, name_fr, name_it, name_rm
+            FROM product_categories
+            ORDER BY display_order, slug
+            "#
+        )
+        .fetch_all(pool)
+        .await?;
         let mut category_by_slug = HashMap::with_capacity(category_rows.len());
+        let mut categories = Vec::with_capacity(category_rows.len());
         for row in category_rows {
-            category_by_slug.insert(row.slug, row.id);
+            category_by_slug.insert(row.slug.clone(), row.id);
+            categories.push(CategoryInfo {
+                slug: row.slug,
+                labels: LocalisedLabels {
+                    de: row.key_de,
+                    en: row.name_en,
+                    fr: row.name_fr,
+                    it: row.name_it,
+                    rm: row.name_rm,
+                },
+            });
         }
 
         Ok(Self {
             by_slug,
             by_id,
             category_by_slug,
+            categories,
         })
+    }
+
+    /// Every category group, in display order.
+    pub fn categories(&self) -> &[CategoryInfo] {
+        &self.categories
     }
 
     /// Resolve a slug to a product id, or `None` if the slug is unknown.

--- a/src/taxonomy/mod.rs
+++ b/src/taxonomy/mod.rs
@@ -8,6 +8,10 @@
 //! this snapshot may be empty until seeding has run and the app has been
 //! (re)started.
 
+mod labels;
+
+pub use labels::LocalisedLabels;
+
 use sqlx::PgPool;
 use std::collections::HashMap;
 

--- a/tests/api/language.rs
+++ b/tests/api/language.rs
@@ -170,3 +170,35 @@ async fn language_does_not_change_which_farms_match() {
         "result count varied by language: {counts:?}"
     );
 }
+
+#[tokio::test]
+async fn the_detail_endpoint_echoes_the_language_too() {
+    // The list endpoint reports which language it resolved to; the detail one
+    // must as well, or a client has to special-case which response it is
+    // reading to answer the same question.
+    let app = spawn_app(IdempotencyEngine::None).await;
+    let farm_id = insert_test_farm(&app.db_pool, "Echo Farm").await;
+
+    for (query, expected) in [
+        ("", "en"),
+        ("?lang=de", "de"),
+        ("?lang=fr-CH", "fr"),
+        ("?lang=", "en"),
+    ] {
+        let body: serde_json::Value = app
+            .api_client
+            .get(format!("{}/farms/{farm_id}{query}", app.address))
+            .send()
+            .await
+            .expect("Failed to execute request.")
+            .json()
+            .await
+            .unwrap();
+
+        assert_eq!(body["lang"], expected, "query={query:?}");
+        // Flattened, so the farm's own fields stay exactly where they were.
+        assert_eq!(body["id"], farm_id.to_string(), "query={query:?}");
+        assert_eq!(body["name"], "Echo Farm", "query={query:?}");
+        assert!(body["products"].is_array(), "query={query:?}");
+    }
+}

--- a/tests/api/language.rs
+++ b/tests/api/language.rs
@@ -1,0 +1,172 @@
+use crate::helpers::{insert_test_farm, spawn_app};
+use actix_web::http::StatusCode;
+use farms::configuration::IdempotencyEngine;
+
+/// The `lang` the server resolved for a list request.
+async fn resolved_lang(response: reqwest::Response) -> String {
+    let body: serde_json::Value = response.json().await.unwrap();
+    body["lang"].as_str().unwrap().to_string()
+}
+
+#[tokio::test]
+async fn defaults_to_english_when_no_language_is_requested() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Default Language Farm").await;
+
+    let response = app
+        .api_client
+        .get(format!("{}/farms", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    // Echoing the resolution back is what lets a client tell "defaulted" apart
+    // from "honoured my request".
+    assert_eq!(resolved_lang(response).await, "en");
+}
+
+#[tokio::test]
+async fn honours_every_supported_language() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Multilingual Farm").await;
+
+    for code in ["en", "de", "fr", "it", "rm"] {
+        let response = app
+            .api_client
+            .get(format!("{}/farms?lang={code}", app.address))
+            .send()
+            .await
+            .expect("Failed to execute request.");
+
+        assert_eq!(
+            response.status().as_u16(),
+            StatusCode::OK.as_u16(),
+            "lang={code}"
+        );
+        assert_eq!(resolved_lang(response).await, code);
+    }
+}
+
+#[tokio::test]
+async fn accepts_a_regional_tag_and_reports_the_base_language() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Swiss German Farm").await;
+
+    // Swiss clients commonly send de-CH; it must not be a client error.
+    let response = app
+        .api_client
+        .get(format!("{}/farms?lang=de-CH", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    assert_eq!(resolved_lang(response).await, "de");
+}
+
+#[tokio::test]
+async fn is_case_insensitive() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Shouty Farm").await;
+
+    let response = app
+        .api_client
+        .get(format!("{}/farms?lang=DE", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    assert_eq!(resolved_lang(response).await, "de");
+}
+
+#[tokio::test]
+async fn rejects_an_unsupported_language_with_400() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+
+    let response = app
+        .api_client
+        .get(format!("{}/farms?lang=es", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Consistent with unknown category/product slugs: a caller who asked for
+    // something specific is told they did not get it.
+    assert_eq!(response.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
+    let body = response.text().await.unwrap();
+    assert!(body.contains("es"), "message should name the input: {body}");
+    assert!(
+        body.contains("en, de, fr, it, rm"),
+        "message should list the supported codes: {body}"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_language_parameter_falls_back_to_the_default() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Empty Lang Farm").await;
+
+    // `?lang=` reads as "unset", not as a typo.
+    let response = app
+        .api_client
+        .get(format!("{}/farms?lang=", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+    assert_eq!(resolved_lang(response).await, "en");
+}
+
+#[tokio::test]
+async fn the_detail_endpoint_validates_the_language_too() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    let farm = insert_test_farm(&app.db_pool, "Detail Farm").await;
+
+    let ok = app
+        .api_client
+        .get(format!("{}/farms/{farm}?lang=fr", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+    assert_eq!(ok.status().as_u16(), StatusCode::OK.as_u16());
+
+    // Both endpoints reject the same way, so the contract is learnable from
+    // either one.
+    let rejected = app
+        .api_client
+        .get(format!("{}/farms/{farm}?lang=es", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+    assert_eq!(rejected.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
+}
+
+#[tokio::test]
+async fn language_does_not_change_which_farms_match() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm(&app.db_pool, "Stable Keys Farm").await;
+    insert_test_farm(&app.db_pool, "Another Farm").await;
+
+    // The whole point of separating keys from labels: switching language must
+    // never change the result set, only how it reads.
+    let mut counts = Vec::new();
+    for code in ["en", "de", "fr", "it", "rm"] {
+        let body: serde_json::Value = app
+            .api_client
+            .get(format!("{}/farms?lang={code}", app.address))
+            .send()
+            .await
+            .expect("Failed to execute request.")
+            .json()
+            .await
+            .unwrap();
+        counts.push(body["farms"].as_array().unwrap().len());
+    }
+    assert!(
+        counts.windows(2).all(|w| w[0] == w[1]),
+        "result count varied by language: {counts:?}"
+    );
+}

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -11,3 +11,4 @@ mod moderation;
 mod products;
 mod registration;
 mod suggestions;
+mod taxonomy;

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -5,6 +5,7 @@ mod authentication;
 mod directory;
 mod farms;
 mod health_check;
+mod language;
 mod me;
 mod moderation;
 mod products;

--- a/tests/api/taxonomy.rs
+++ b/tests/api/taxonomy.rs
@@ -127,3 +127,64 @@ async fn is_reachable_without_authentication() {
 
     assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
 }
+
+/// Whether a failure was the label constraint rather than some unrelated error.
+///
+/// Asserting only `is_err()` would let this test pass for the wrong reason — a
+/// typo'd column or a unique violation would look identical.
+fn violates_the_label_constraint(error: &sqlx::Error) -> bool {
+    error
+        .as_database_error()
+        .and_then(|db| db.constraint())
+        .is_some_and(|name| name == "product_categories_labels_not_blank")
+}
+
+#[tokio::test]
+async fn the_database_rejects_a_blank_label() {
+    // Everything /taxonomy promises about `name` rests on NULL being the only
+    // spelling of "missing". Postgres `text` would otherwise accept '' and
+    // '   ', which read as translated and render as nothing at all.
+    let app = spawn_app(IdempotencyEngine::None).await;
+
+    // Static SQL per case: the column name varies, and interpolating it would
+    // (rightly) trip the dynamic-SQL lint.
+    let rejected = [
+        (
+            "an empty translation",
+            "INSERT INTO product_categories (key_de, slug, display_order, name_en)
+             VALUES ('Kanonisch', 'blank-en', 0, '')",
+        ),
+        (
+            "a whitespace-only translation",
+            "INSERT INTO product_categories (key_de, slug, display_order, name_fr)
+             VALUES ('Kanonisch', 'blank-fr', 0, '   ')",
+        ),
+        (
+            "a blank canonical label",
+            "INSERT INTO product_categories (key_de, slug, display_order, name_en)
+             VALUES ('', 'blank-de', 0, 'Canonical')",
+        ),
+    ];
+
+    for (description, statement) in rejected {
+        let error = sqlx::query(statement)
+            .execute(&app.db_pool)
+            .await
+            .expect_err(&format!("{description} must be rejected"));
+
+        assert!(
+            violates_the_label_constraint(&error),
+            "{description} should trip the label constraint, got: {error}"
+        );
+    }
+
+    // NULL stays the supported way to say "not translated yet" — the constraint
+    // must not have made the columns effectively mandatory.
+    sqlx::query(
+        "INSERT INTO product_categories (key_de, slug, display_order, name_en)
+         VALUES ('Kanonisch', 'null-en', 0, NULL)",
+    )
+    .execute(&app.db_pool)
+    .await
+    .expect("an untranslated category must still be insertable");
+}

--- a/tests/api/taxonomy.rs
+++ b/tests/api/taxonomy.rs
@@ -1,0 +1,129 @@
+use crate::helpers::{seed_test_taxonomy, spawn_app};
+use actix_web::http::StatusCode;
+use farms::configuration::IdempotencyEngine;
+
+async fn taxonomy(app: &crate::helpers::TestApp, query: &str) -> serde_json::Value {
+    app.api_client
+        .get(format!("{}/taxonomy{query}", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.")
+        .json()
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn returns_the_category_vocabulary() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    seed_test_taxonomy(&app.db_pool).await;
+
+    let body = taxonomy(&app, "").await;
+    let categories = body["categories"].as_array().unwrap();
+
+    assert!(!categories.is_empty(), "expected some categories");
+    // Every entry carries the stable key AND something displayable — a client
+    // should never have to invent a label.
+    for category in categories {
+        assert!(category["slug"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(category["name"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(category["translated"].is_boolean());
+    }
+}
+
+#[tokio::test]
+async fn labels_change_with_the_language_but_slugs_do_not() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    seed_test_taxonomy(&app.db_pool).await;
+
+    let slugs_for = |body: &serde_json::Value| -> Vec<String> {
+        body["categories"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["slug"].as_str().unwrap().to_string())
+            .collect()
+    };
+
+    let en = taxonomy(&app, "?lang=en").await;
+    let de = taxonomy(&app, "?lang=de").await;
+
+    // The identity is stable across languages — that is the whole contract.
+    assert_eq!(slugs_for(&en), slugs_for(&de));
+    assert_eq!(en["lang"], "en");
+    assert_eq!(de["lang"], "de");
+}
+
+#[tokio::test]
+async fn defaults_to_english_without_a_language() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    seed_test_taxonomy(&app.db_pool).await;
+
+    let body = taxonomy(&app, "").await;
+    assert_eq!(body["lang"], "en");
+}
+
+#[tokio::test]
+async fn rejects_an_unsupported_language() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+
+    let response = app
+        .api_client
+        .get(format!("{}/taxonomy?lang=es", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // Same contract as /farms — a client learns it once.
+    assert_eq!(response.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
+}
+
+#[tokio::test]
+async fn serves_the_real_translation_for_each_language() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    seed_test_taxonomy(&app.db_pool).await;
+
+    // The seeded labels are authored translations, so this pins actual output
+    // rather than "some non-empty string" — which would pass even if every
+    // language silently fell back to German.
+    let expected = [
+        ("en", "Vegetables"),
+        ("de", "Gemüse"),
+        ("fr", "Légumes"),
+        ("it", "Verdura"),
+        ("rm", "Verduras"),
+    ];
+
+    for (code, label) in expected {
+        let body = taxonomy(&app, &format!("?lang={code}")).await;
+        let vegetables = body["categories"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["slug"] == "vegetables")
+            .expect("vegetables category");
+
+        assert_eq!(vegetables["name"], label, "lang={code}");
+        // All five are authored for categories, so none should be a fallback.
+        assert_eq!(
+            vegetables["translated"], true,
+            "lang={code} should be a real translation, not a fallback"
+        );
+    }
+}
+
+#[tokio::test]
+async fn is_reachable_without_authentication() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    seed_test_taxonomy(&app.db_pool).await;
+
+    // Pickers and type-aheads need this before a visitor has any session.
+    let response = app
+        .api_client
+        .get(format!("{}/taxonomy", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(response.status().as_u16(), StatusCode::OK.as_u16());
+}

--- a/tests/api/taxonomy.rs
+++ b/tests/api/taxonomy.rs
@@ -188,3 +188,51 @@ async fn the_database_rejects_a_blank_label() {
     .await
     .expect("an untranslated category must still be insertable");
 }
+
+#[tokio::test]
+async fn is_cacheable() {
+    // The vocabulary is a startup snapshot, so it cannot change until the app
+    // restarts. Clients on the critical path (pickers, type-aheads) should not
+    // re-fetch it on every navigation, and the doc comment claiming it is a
+    // "good candidate for caching" is worth nothing without the header.
+    let app = spawn_app(IdempotencyEngine::None).await;
+    seed_test_taxonomy(&app.db_pool).await;
+
+    let response = app
+        .api_client
+        .get(format!("{}/taxonomy", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    let cache_control = response
+        .headers()
+        .get("cache-control")
+        .expect("Cache-Control must be set")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    assert!(cache_control.contains("public"), "got: {cache_control}");
+    assert!(cache_control.contains("max-age="), "got: {cache_control}");
+}
+
+#[tokio::test]
+async fn a_rejected_language_is_not_cached() {
+    // A 400 must not be cached as though it were the vocabulary — a client that
+    // fixed its `lang` should not keep being served the error.
+    let app = spawn_app(IdempotencyEngine::None).await;
+
+    let response = app
+        .api_client
+        .get(format!("{}/taxonomy?lang=es", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(response.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
+    assert!(
+        response.headers().get("cache-control").is_none(),
+        "a 400 carried a Cache-Control header"
+    );
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -488,8 +488,21 @@ pub struct TestTaxonomy {
 /// Insert the standard test taxonomy. Called by `spawn_app` before the app
 /// boots so the app's startup snapshot resolves these slugs.
 async fn seed_standard_taxonomy(pool: &PgPool) {
-    let fruits = insert_test_category(pool, "Früchte", "fruits", 0).await;
-    let vegetables = insert_test_category(pool, "Gemüse", "vegetables", 1).await;
+    let fruits = insert_test_category(
+        pool, "Früchte", "fruits", 0, "Fruits", "Fruits", "Frutta", "Fritgs",
+    )
+    .await;
+    let vegetables = insert_test_category(
+        pool,
+        "Gemüse",
+        "vegetables",
+        1,
+        "Vegetables",
+        "Légumes",
+        "Verdura",
+        "Verduras",
+    )
+    .await;
     insert_test_product(pool, fruits, "Erdbeeren", "strawberries", "Strawberries").await;
     insert_test_product(pool, fruits, "Kirschen", "cherries", "Cherries").await;
     insert_test_product(pool, vegetables, "Broccoli", "broccoli", "Broccoli").await;
@@ -519,16 +532,36 @@ pub async fn seed_test_taxonomy(pool: &PgPool) -> TestTaxonomy {
 }
 
 #[allow(dead_code)]
-async fn insert_test_category(pool: &PgPool, key_de: &str, slug: &str, display_order: i16) -> i16 {
+/// Insert a category with its full set of display labels.
+///
+/// The labels are passed in rather than left null so tests exercise real
+/// localised output. Seeding German only would let a bug where every language
+/// silently falls back to German pass unnoticed.
+#[allow(clippy::too_many_arguments)]
+async fn insert_test_category(
+    pool: &PgPool,
+    key_de: &str,
+    slug: &str,
+    display_order: i16,
+    name_en: &str,
+    name_fr: &str,
+    name_it: &str,
+    name_rm: &str,
+) -> i16 {
     sqlx::query!(
         r#"
-        INSERT INTO product_categories (key_de, slug, display_order)
-        VALUES ($1, $2, $3)
+        INSERT INTO product_categories
+            (key_de, slug, display_order, name_en, name_fr, name_it, name_rm)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
         RETURNING id
         "#,
         key_de,
         slug,
         display_order,
+        name_en,
+        name_fr,
+        name_it,
+        name_rm,
     )
     .fetch_one(pool)
     .await


### PR DESCRIPTION
Closes #129. Second of the stack for epic #126 — **targets [#161](https://github.com/PedroGalveias/farms/pull/161), not `main`.**

## What lands

- `product_categories` gains `name_en` / `name_fr` / `name_it` / `name_rm`
- `LocalisedLabels::resolve` — requested → English → German
- **`GET /taxonomy?lang=`** — the full category vocabulary with labels

All 13 categories have real authored translations in all five languages, carried over from the web frontend. `Légumes`, `Products da latg`, `Nuschs, sems ed ieli` — human-written, Romansh included. That is why they were worth migrating rather than regenerating.

## Why an endpoint, not labels on /farms

Any client with a picker, a type-ahead or an offline mode needs the **full** category list, not just the groups attached to farms in the current response. Labels on `/farms` alone would leave every client maintaining a duplicate list by hand — the exact situation this epic set out to remove.

So `/farms` keeps returning slugs. Repeating thirteen strings across three thousand farms is a lot of bytes to say something a client can fetch once and cache.

## A bug my dev database hid

Worth reading, because the first cut looked correct and passed locally.

I put the label values in the migration as `UPDATE ... WHERE slug = ...`. The 13 category rows are inserted by `scripts/seed_products.py`, which runs **after** migrations — so on a fresh database those UPDATEs matched **zero rows** and every label stayed null. CI, a new environment and a rebuilt production would all have been silently unlocalised. It only worked on my machine because the rows already existed.

Caught by strengthening a test to assert `Vegetables` rather than "some non-empty string": it returned `Gemüse`, the German fallback.

The migration is now schema-only and the labels live in the seeder that owns the taxonomy's content, upserted so re-running applies them to existing databases too.

**Operational note:** existing environments need `seed_products.py` re-run to pick up the labels. Until then `/taxonomy` serves the German fallback — correct, just not yet localised.

## Test fixtures now carry real labels

The fixture seeded German only, which cannot distinguish a working translation from a fallback — every language would have resolved to German and passed. It now seeds all five, and the test asserts each language's string individually.

## `translated`

Each entry reports whether its label is a real translation or a fallback. Resolution alone cannot answer that — everything always resolves to *something* — and with #162 outstanding, being able to state coverage honestly matters.

## Verification

- 7 unit tests on the resolver, 6 integration tests on the endpoint
- **168 unit + 91 integration** green
- `fmt`, `clippy -D warnings` clean, `.sqlx` regenerated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public `/taxonomy` endpoint for retrieving product categories.
  * Supports German, English, French, Italian, and Romansh labels with language fallback.
  * Indicates whether each returned category name is directly translated.
  * Added localized category labels to product data and seeding.

* **Bug Fixes**
  * Invalid language selections now return a validation error.

* **Tests**
  * Added coverage for translations, fallbacks, stable slugs, accessibility, and response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
