### PR TITLE
chore: ignore the ad-hoc binaries that sit in the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@
 /coverage
 .DS_Store
 seed.sql
+
+# Ad-hoc binaries from local experiments. They land at the repo root rather
+# than under /target, so nothing else here excludes them and `git add -A`
+# happily commits half a megabyte of Mach-O apiece.
+/dead_chain*
+/dead_code_check*
+
+# Local editor/assistant tooling config.
+.ai/


### PR DESCRIPTION
Seven ~440KB Mach-O arm64 executables (`dead_chain`, `dead_chain_allow`, `dead_chain_expect`, `dead_code_check`, `dead_code_check2..4`) and the local `.ai/` tooling directory have been sitting untracked in the working tree. A single `git add -A` swept all of them into #161, where they survived every check — rustfmt, clippy, coverage and CodeQL all ignore committed binaries. Only CodeRabbit's out-of-scope check noticed, and only because it reads the file list rather than the code.

They land at the repo root rather than under `/target`, so nothing in the existing `.gitignore` covered them.

### Deliberately still visible

`docs/`, `github_issue_descriptions.md` and `point_guide_markdown.md` are left untracked-but-unignored. They are prose someone may want to commit on purpose one day; ignoring them would quietly remove that option instead of preventing a mistake.

### Verification

```
$ git check-ignore -v dead_chain dead_code_check4 .ai/mcp/mcp.json
.gitignore:12:/dead_chain*      dead_chain
.gitignore:13:/dead_code_check* dead_code_check4
.gitignore:16:.ai/              .ai/mcp/mcp.json
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project file exclusions to omit temporary analysis artifacts and internal tooling directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->