### PR TITLE
feat: GET /facets — how many farms sit behind each filter option

### DIFF
--- a/.sqlx/query-2f75b4ebded8d0ed489e6ac5668fd9632db086dc7c4fcd37e90e9d555d1aaaf1.json
+++ b/.sqlx/query-2f75b4ebded8d0ed489e6ac5668fd9632db086dc7c4fcd37e90e9d555d1aaaf1.json
@@ -1,0 +1,33 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT f.canton AS \"canton: Canton\", count(*) AS \"count!\"\n        FROM farms f\n        GROUP BY f.canton\n        ORDER BY f.canton\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "canton: Canton",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "farms",
+            "name": "canton"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "count!",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "2f75b4ebded8d0ed489e6ac5668fd9632db086dc7c4fcd37e90e9d555d1aaaf1"
+}

--- a/.sqlx/query-6f55a52ade09d73b01c4653aea44e2352e87045a6a0ef42fe9203be496bde792.json
+++ b/.sqlx/query-6f55a52ade09d73b01c4653aea44e2352e87045a6a0ef42fe9203be496bde792.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO farms (id, name, address, canton, coordinates, created_at, updated_at)\n        VALUES ($1, $2, 'Somewhere 1', $3, POINT(8.5, 47.4), now(), NULL)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6f55a52ade09d73b01c4653aea44e2352e87045a6a0ef42fe9203be496bde792"
+}

--- a/.sqlx/query-79c08fd840ef6d3fcc5ac0609788c799c05e165cc32d4cd3f49d2dbdc63f6ac0.json
+++ b/.sqlx/query-79c08fd840ef6d3fcc5ac0609788c799c05e165cc32d4cd3f49d2dbdc63f6ac0.json
@@ -1,0 +1,33 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT c.slug, count(DISTINCT m.farm_id) AS \"count!\"\n        FROM product_categories c\n        LEFT JOIN (\n            SELECT fc.category_id, fc.farm_id\n            FROM farm_categories fc\n            UNION\n            SELECT p.category_id, fp.farm_id\n            FROM farm_products fp\n            JOIN products p ON p.id = fp.product_id\n        ) m ON m.category_id = c.id\n        GROUP BY c.id, c.slug\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "slug",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "product_categories",
+            "name": "slug"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "count!",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "79c08fd840ef6d3fcc5ac0609788c799c05e165cc32d4cd3f49d2dbdc63f6ac0"
+}

--- a/.sqlx/query-d66166ead9996094b6b815ca7d5f6c5eaebc63473b7d8f72c410912ef9f2dcaa.json
+++ b/.sqlx/query-d66166ead9996094b6b815ca7d5f6c5eaebc63473b7d8f72c410912ef9f2dcaa.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT count(*) AS \"count!\" FROM farms",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "d66166ead9996094b6b815ca7d5f6c5eaebc63473b7d8f72c410912ef9f2dcaa"
+}

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The service currently exposes:
 - `GET /farms` — the directory (filters, geo, pagination — see below)
 - `GET /farms/{id}`
 - `GET /taxonomy` — the filtering vocabulary with display labels (see below)
+- `GET /facets` — how many farms sit behind each filter option (see below)
 - `POST /farms`
 - `POST /farms/{id}/product-suggestions` — suggest a product for a farm
 - `GET /admin/product-suggestions` — moderation queue (admin only)
@@ -297,6 +298,51 @@ Product labels in fr/it/rm do not exist in the source dataset. Until they are
 authored ([#162](https://github.com/PedroGalveias/farms/issues/162)), asking for
 `?lang=rm` returns English product names with `"translated": false` — which is
 the honest answer, not a bug.
+
+### Filter Counts — `GET /facets`
+
+How many farms sit behind each filter option, so a client can build a picker
+without holding the whole directory in memory.
+
+This exists for a specific reason. A directory that derives its own filter
+options from the farms it was handed can only offer the options present in that
+subset — so the moment it asks the API for a *filtered* set, its canton picker
+contains only the canton it already filtered to, and the visitor cannot get back
+out. Counts have to come from somewhere that always sees everything.
+
+```
+GET /facets
+GET /facets?lang=de
+```
+
+```json
+{
+  "lang": "de",
+  "total": 3155,
+  "cantons": [{ "code": "AG", "count": 118 }, { "code": "BE", "count": 727 }],
+  "categories": [
+    { "slug": "fruits", "name": "Früchte", "translated": true, "count": 412 },
+    { "slug": "fish-seafood", "name": "Fisch und Meeresfrüchte", "translated": true, "count": 0 }
+  ]
+}
+```
+
+- **`cantons`** lists only cantons that have farms — a canton nobody farms in
+  would be a dead option in a picker.
+- **`categories`** is exhaustive, including counts of zero, mirroring
+  `GET /taxonomy`: a picker needs the full vocabulary, and the count is what
+  tells it which options to grey out.
+- A farm counts once per category whether it is tagged **directly** or through
+  a **product** in that category — the same "any of" rule `?category=` applies
+  on `GET /farms`, so a count always agrees with what filtering would return.
+
+Counts are **unfiltered on purpose**: they describe the whole directory, so an
+option's count does not shift as other filters are applied. That is what makes
+them a stable ordering for a picker. Contextual counts are a different question
+and would take the same filter parameters as `GET /farms`.
+
+Cached `public, max-age=300, stale-while-revalidate=3600` — matched to how long
+a client caches `GET /farms`, so a count never disagrees with the list beside it.
 
 ### The Vocabulary — `GET /taxonomy`
 

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ subset — so the moment it asks the API for a *filtered* set, its canton picker
 contains only the canton it already filtered to, and the visitor cannot get back
 out. Counts have to come from somewhere that always sees everything.
 
-```
+```text
 GET /facets
 GET /facets?lang=de
 ```

--- a/src/routes/facets/get.rs
+++ b/src/routes/facets/get.rs
@@ -91,9 +91,24 @@ pub async fn get_facets(
     let language = Language::from_query(query.lang.as_deref())
         .map_err(|e| FarmError::ValidationError(e.to_string()))?;
 
-    // One round trip per facet rather than one query with several CTEs: each is
-    // an index-friendly aggregate, and keeping them apart means a change to one
-    // cannot silently alter another's grouping.
+    // All three aggregates read ONE snapshot of the directory.
+    //
+    // Separate statements on the pool each see their own committed state, so a
+    // farm created or deleted between them could leave `total`, `cantons` and
+    // `categories` describing different directories. This response is then
+    // cached for five minutes, so such an inconsistency would be served over
+    // and over rather than corrected on the next request. REPEATABLE READ pins
+    // one snapshot for the whole transaction; READ ONLY says plainly that
+    // nothing here writes.
+    let mut tx = pool
+        .begin()
+        .await
+        .context("Failed to start the facets transaction.")?;
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
+        .execute(&mut *tx)
+        .await
+        .context("Failed to pin the facets snapshot.")?;
+
     let canton_rows = sqlx::query!(
         r#"
         SELECT f.canton AS "canton: Canton", count(*) AS "count!"
@@ -102,7 +117,7 @@ pub async fn get_facets(
         ORDER BY f.canton
         "#,
     )
-    .fetch_all(pool.get_ref())
+    .fetch_all(&mut *tx)
     .await
     .context("Failed to count farms per canton.")?;
 
@@ -125,14 +140,20 @@ pub async fn get_facets(
         GROUP BY c.id, c.slug
         "#,
     )
-    .fetch_all(pool.get_ref())
+    .fetch_all(&mut *tx)
     .await
     .context("Failed to count farms per category.")?;
 
     let total = sqlx::query_scalar!(r#"SELECT count(*) AS "count!" FROM farms"#)
-        .fetch_one(pool.get_ref())
+        .fetch_one(&mut *tx)
         .await
         .context("Failed to count farms.")?;
+
+    // Read-only, so commit and rollback are equivalent; commit is the honest
+    // close and returns the connection to the pool either way.
+    tx.commit()
+        .await
+        .context("Failed to close the facets transaction.")?;
 
     let counts: std::collections::HashMap<&str, i64> = category_rows
         .iter()

--- a/src/routes/facets/get.rs
+++ b/src/routes/facets/get.rs
@@ -1,0 +1,172 @@
+use crate::{
+    domain::{farm::Canton, language::Language},
+    routes::farms::FarmError,
+    taxonomy::TaxonomySnapshot,
+};
+use actix_web::{HttpResponse, http::header, web};
+use anyhow::Context;
+use sqlx::PgPool;
+
+/// Query parameters for `GET /facets`.
+#[derive(Debug, serde::Deserialize)]
+pub struct FacetsQuery {
+    /// Display language for category labels — see `FarmListQuery::lang`.
+    pub lang: Option<String>,
+}
+
+/// How many farms are in one canton.
+#[derive(serde::Serialize)]
+pub struct CantonFacet {
+    /// Two-letter canton code, e.g. `BE`.
+    pub code: Canton,
+    pub count: i64,
+}
+
+/// How many farms are in one category group.
+#[derive(serde::Serialize)]
+pub struct CategoryFacet {
+    /// Stable, language-independent identifier — what `?category=` takes.
+    pub slug: String,
+    /// Display label in the requested language, falling back where a
+    /// translation is missing.
+    pub name: String,
+    /// Whether `name` is a real translation or a fallback.
+    pub translated: bool,
+    pub count: i64,
+}
+
+/// Counts across the whole directory.
+#[derive(serde::Serialize)]
+pub struct FacetsResponse {
+    /// The language the labels were resolved to.
+    pub lang: Language,
+    /// Every farm in the directory, so a client can show "N farms" without
+    /// paging through the list to count them.
+    pub total: i64,
+    /// Only cantons that actually have farms. A canton with none would render
+    /// as a dead option in a picker.
+    pub cantons: Vec<CantonFacet>,
+    /// Every category in the taxonomy, including those with a count of zero —
+    /// a picker needs the full vocabulary, and the count tells it what to grey
+    /// out. This mirrors `GET /taxonomy`, which is also exhaustive.
+    pub categories: Vec<CategoryFacet>,
+}
+
+/// How long a client may reuse this response.
+///
+/// Matched to the 5 minutes the frontend already caches `GET /farms` for: these
+/// counts describe that same data, and letting them drift apart would show a
+/// visitor "412 farms" next to a list of a different length. `stale-while-
+/// revalidate` lets a picker render instantly from a slightly old copy while
+/// the refresh happens behind it, which matters because these counts are on the
+/// critical path for the directory's filter UI.
+///
+/// `public`: the response depends only on `?lang=`, which is in the URL. No
+/// session, no `Vary` needed.
+const CACHE_CONTROL: &str = "public, max-age=300, stale-while-revalidate=3600";
+
+/// `GET /facets` — how many farms sit behind each filter option.
+///
+/// This exists because a client cannot derive these counts without holding the
+/// entire directory in memory. The frontend did exactly that: it fetched all
+/// ~3,155 farms on every route that showed a filter, purely so it could count
+/// them per canton and per category. That is the one thing keeping it from
+/// asking the API for a filtered subset — filter server-side to one canton and
+/// a locally-derived picker can only offer that canton, so the visitor cannot
+/// get back out.
+///
+/// Counts are **unfiltered on purpose**. They describe the whole directory, so
+/// a filter option's count does not change as other filters are applied. That
+/// is what makes them a stable ordering for a picker — the frontend already
+/// sorts its category chips by overall availability "so chips keep their place
+/// as the contextual counts below change". Contextual counts, if wanted later,
+/// are a different question and would take the same filter parameters as
+/// `GET /farms`.
+#[tracing::instrument(name = "Get facets", skip(pool, taxonomy))]
+pub async fn get_facets(
+    query: web::Query<FacetsQuery>,
+    pool: web::Data<PgPool>,
+    taxonomy: web::Data<TaxonomySnapshot>,
+) -> Result<HttpResponse, FarmError> {
+    let language = Language::from_query(query.lang.as_deref())
+        .map_err(|e| FarmError::ValidationError(e.to_string()))?;
+
+    // One round trip per facet rather than one query with several CTEs: each is
+    // an index-friendly aggregate, and keeping them apart means a change to one
+    // cannot silently alter another's grouping.
+    let canton_rows = sqlx::query!(
+        r#"
+        SELECT f.canton AS "canton: Canton", count(*) AS "count!"
+        FROM farms f
+        GROUP BY f.canton
+        ORDER BY f.canton
+        "#,
+    )
+    .fetch_all(pool.get_ref())
+    .await
+    .context("Failed to count farms per canton.")?;
+
+    // A farm belongs to a category either directly (`farm_categories`) or
+    // through a product in that category — the same "any of" rule
+    // `GET /farms?category=` applies. UNION rather than UNION ALL, so a farm
+    // tagged both ways is counted once.
+    let category_rows = sqlx::query!(
+        r#"
+        SELECT c.slug, count(DISTINCT m.farm_id) AS "count!"
+        FROM product_categories c
+        LEFT JOIN (
+            SELECT fc.category_id, fc.farm_id
+            FROM farm_categories fc
+            UNION
+            SELECT p.category_id, fp.farm_id
+            FROM farm_products fp
+            JOIN products p ON p.id = fp.product_id
+        ) m ON m.category_id = c.id
+        GROUP BY c.id, c.slug
+        "#,
+    )
+    .fetch_all(pool.get_ref())
+    .await
+    .context("Failed to count farms per category.")?;
+
+    let total = sqlx::query_scalar!(r#"SELECT count(*) AS "count!" FROM farms"#)
+        .fetch_one(pool.get_ref())
+        .await
+        .context("Failed to count farms.")?;
+
+    let counts: std::collections::HashMap<&str, i64> = category_rows
+        .iter()
+        .map(|row| (row.slug.as_str(), row.count))
+        .collect();
+
+    // Driven by the taxonomy snapshot, not by the query, so the list and its
+    // order match `GET /taxonomy` exactly and a category with no farms yet
+    // still appears.
+    let categories = taxonomy
+        .categories()
+        .iter()
+        .map(|category| CategoryFacet {
+            slug: category.slug.clone(),
+            name: category.labels.resolve(language).to_string(),
+            translated: category.labels.has(language),
+            count: counts.get(category.slug.as_str()).copied().unwrap_or(0),
+        })
+        .collect();
+
+    let cantons = canton_rows
+        .into_iter()
+        .map(|row| CantonFacet {
+            code: row.canton,
+            count: row.count,
+        })
+        .collect();
+
+    Ok(HttpResponse::Ok()
+        .insert_header((header::CACHE_CONTROL, CACHE_CONTROL))
+        .json(FacetsResponse {
+            lang: language,
+            total,
+            cantons,
+            categories,
+        }))
+}

--- a/src/routes/facets/mod.rs
+++ b/src/routes/facets/mod.rs
@@ -1,0 +1,3 @@
+mod get;
+
+pub use get::get_facets;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,6 @@
 pub mod admin;
 pub mod authentication;
+pub mod facets;
 pub mod farms;
 mod health_check;
 pub mod suggestions;

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -2,7 +2,7 @@ use crate::configuration::{
     DatabaseSettings, RedisSettings, SessionSameSite, SessionSettings, Settings,
 };
 use crate::email_client::EmailClient;
-use crate::routes::{admin, authentication, farms, health_check, suggestions, taxonomy};
+use crate::routes::{admin, authentication, facets, farms, health_check, suggestions, taxonomy};
 use actix_session::{
     SessionMiddleware,
     config::{CookieContentSecurity, PersistentSession, TtlExtensionPolicy},
@@ -186,6 +186,7 @@ pub async fn run(
             .route("/farms", web::get().to(farms::get_all))
             .route("/farms/{id}", web::get().to(farms::get_by_id))
             .route("/taxonomy", web::get().to(taxonomy::get_taxonomy))
+            .route("/facets", web::get().to(facets::get_facets))
             .route(
                 "/farms/{id}/product-suggestions",
                 web::post().to(suggestions::submit_suggestion),

--- a/tests/api/facets.rs
+++ b/tests/api/facets.rs
@@ -1,0 +1,197 @@
+use crate::helpers::{
+    insert_test_farm_in_canton, link_farm_category, link_farm_product, seed_test_taxonomy,
+    spawn_app,
+};
+use actix_web::http::StatusCode;
+use farms::configuration::IdempotencyEngine;
+
+async fn facets(app: &crate::helpers::TestApp, query: &str) -> serde_json::Value {
+    app.api_client
+        .get(format!("{}/facets{query}", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.")
+        .json()
+        .await
+        .unwrap()
+}
+
+fn count_for(body: &serde_json::Value, list: &str, key: &str, value: &str) -> i64 {
+    body[list]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry[key].as_str() == Some(value))
+        .unwrap_or_else(|| panic!("no {list} entry for {value}"))["count"]
+        .as_i64()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn counts_farms_per_canton() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+
+    insert_test_farm_in_canton(&app.db_pool, "Berner Hof A", "BE").await;
+    insert_test_farm_in_canton(&app.db_pool, "Berner Hof B", "BE").await;
+    insert_test_farm_in_canton(&app.db_pool, "Zürcher Hof", "ZH").await;
+
+    let body = facets(&app, "").await;
+
+    assert_eq!(count_for(&body, "cantons", "code", "BE"), 2);
+    assert_eq!(count_for(&body, "cantons", "code", "ZH"), 1);
+    assert_eq!(body["total"].as_i64().unwrap(), 3);
+}
+
+#[tokio::test]
+async fn omits_cantons_with_no_farms() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    insert_test_farm_in_canton(&app.db_pool, "Only farm", "BE").await;
+
+    let body = facets(&app, "").await;
+    let codes: Vec<&str> = body["cantons"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| c["code"].as_str().unwrap())
+        .collect();
+
+    // A canton nobody farms in would be a dead entry in a picker.
+    assert_eq!(codes, vec!["BE"]);
+}
+
+#[tokio::test]
+async fn counts_a_farm_once_when_it_is_tagged_both_ways() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    let taxonomy = seed_test_taxonomy(&app.db_pool).await;
+
+    // Belongs to `fruits` twice over: directly, and through a product in it.
+    // The union that resolves the two paths must not double-count it.
+    let farm = insert_test_farm_in_canton(&app.db_pool, "Doubly tagged", "BE").await;
+    link_farm_category(&app.db_pool, farm, taxonomy.fruits_category_id).await;
+    link_farm_product(&app.db_pool, farm, taxonomy.strawberries_id).await;
+
+    let body = facets(&app, "").await;
+
+    assert_eq!(count_for(&body, "categories", "slug", "fruits"), 1);
+}
+
+#[tokio::test]
+async fn counts_a_farm_reached_only_through_a_product() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    let taxonomy = seed_test_taxonomy(&app.db_pool).await;
+
+    // No direct category link at all — the only route to `fruits` is the
+    // product. This is the same "any of" rule `GET /farms?category=` applies,
+    // so the count has to agree with what filtering would return.
+    let farm = insert_test_farm_in_canton(&app.db_pool, "Product only", "BE").await;
+    link_farm_product(&app.db_pool, farm, taxonomy.cherries_id).await;
+
+    let body = facets(&app, "").await;
+
+    assert_eq!(count_for(&body, "categories", "slug", "fruits"), 1);
+}
+
+#[tokio::test]
+async fn lists_every_category_including_empty_ones() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    let taxonomy = seed_test_taxonomy(&app.db_pool).await;
+
+    let farm = insert_test_farm_in_canton(&app.db_pool, "Fruit farm", "BE").await;
+    link_farm_category(&app.db_pool, farm, taxonomy.fruits_category_id).await;
+
+    let body = facets(&app, "").await;
+
+    // A picker needs the whole vocabulary; the count is what tells it which
+    // options to grey out.
+    assert_eq!(count_for(&body, "categories", "slug", "fruits"), 1);
+    assert_eq!(count_for(&body, "categories", "slug", "vegetables"), 0);
+}
+
+#[tokio::test]
+async fn category_labels_follow_the_language_but_slugs_do_not() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    seed_test_taxonomy(&app.db_pool).await;
+
+    let english = facets(&app, "?lang=en").await;
+    let french = facets(&app, "?lang=fr").await;
+
+    let slugs = |body: &serde_json::Value| -> Vec<String> {
+        body["categories"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["slug"].as_str().unwrap().to_string())
+            .collect()
+    };
+    let name_of = |body: &serde_json::Value, slug: &str| -> String {
+        body["categories"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["slug"].as_str() == Some(slug))
+            .unwrap()["name"]
+            .as_str()
+            .unwrap()
+            .to_string()
+    };
+
+    assert_eq!(slugs(&english), slugs(&french));
+    assert_eq!(english["lang"].as_str().unwrap(), "en");
+    assert_eq!(french["lang"].as_str().unwrap(), "fr");
+    assert_eq!(name_of(&english, "vegetables"), "Vegetables");
+    assert_eq!(name_of(&french, "vegetables"), "Légumes");
+}
+
+#[tokio::test]
+async fn rejects_an_unsupported_language() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+
+    let response = app
+        .api_client
+        .get(format!("{}/facets?lang=xx", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    assert_eq!(response.status().as_u16(), StatusCode::BAD_REQUEST.as_u16());
+}
+
+#[tokio::test]
+async fn is_publicly_cacheable() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+
+    let response = app
+        .api_client
+        .get(format!("{}/facets", app.address))
+        .send()
+        .await
+        .expect("Failed to execute request.");
+
+    // These counts describe the same data the frontend caches `GET /farms` for
+    // five minutes; if the two lifetimes drift a visitor sees a count that
+    // disagrees with the list beside it.
+    let cache_control = response
+        .headers()
+        .get("cache-control")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        cache_control.contains("public") && cache_control.contains("max-age=300"),
+        "unexpected cache-control: {cache_control}"
+    );
+}
+
+#[tokio::test]
+async fn reports_zero_for_an_empty_directory() {
+    let app = spawn_app(IdempotencyEngine::None).await;
+    seed_test_taxonomy(&app.db_pool).await;
+
+    let body = facets(&app, "").await;
+
+    assert_eq!(body["total"].as_i64().unwrap(), 0);
+    assert!(body["cantons"].as_array().unwrap().is_empty());
+    // The vocabulary is still there — an empty directory is not an empty picker.
+    assert!(!body["categories"].as_array().unwrap().is_empty());
+    assert_eq!(count_for(&body, "categories", "slug", "fruits"), 0);
+}

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -3,6 +3,7 @@ mod helpers;
 
 mod authentication;
 mod directory;
+mod facets;
 mod farms;
 mod health_check;
 mod language;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -669,6 +669,26 @@ pub async fn insert_test_farm(pool: &PgPool, name: &str) -> Uuid {
     id
 }
 
+/// Insert a bare farm in a specific canton. Same as `insert_test_farm`, for
+/// tests that care where a farm is rather than only that it exists.
+#[allow(dead_code)]
+pub async fn insert_test_farm_in_canton(pool: &PgPool, name: &str, canton: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query!(
+        r#"
+        INSERT INTO farms (id, name, address, canton, coordinates, created_at, updated_at)
+        VALUES ($1, $2, 'Somewhere 1', $3, POINT(8.5, 47.4), now(), NULL)
+        "#,
+        id,
+        name,
+        canton,
+    )
+    .execute(pool)
+    .await
+    .expect("Failed to insert test farm.");
+    id
+}
+
 /// Link a farm to a granular product.
 #[allow(dead_code)]
 pub async fn link_farm_product(pool: &PgPool, farm_id: Uuid, product_id: i32) {


### PR DESCRIPTION
Unblocks the frontend's server-side directory filtering, which is currently
impossible for a reason that isn't obvious until you try it.

### Why this is needed

A client that derives its filter options from the farms it was handed can only
offer the options present in that subset. So the moment the frontend asks for a
**filtered** set, its canton picker contains only the canton it already filtered
to — and the visitor cannot get back out.

That is why the frontend still downloads all ~3,155 farms on every route with a
filter UI: not to render them, but to count them per canton and per category
(`getCategoryCounts(initialFarms)`, `getUniqueFarmCantons(initialFarms)`).
Counts have to come from somewhere that always sees everything.

### The endpoint

```
GET /facets
GET /facets?lang=de
```

```json
{
  "lang": "de",
  "total": 3155,
  "cantons": [{ "code": "BE", "count": 727 }],
  "categories": [
    { "slug": "fruits", "name": "Früchte", "translated": true, "count": 412 },
    { "slug": "fish-seafood", "name": "Fisch und Meeresfrüchte", "translated": true, "count": 0 }
  ]
}
```

### Semantics worth reviewing

- **`cantons`** lists only cantons that have farms — a canton nobody farms in is
  a dead option in a picker.
- **`categories`** is exhaustive, zero counts included, mirroring `GET /taxonomy`:
  a picker needs the whole vocabulary, and the count is what greys an option out.
- **A farm counts once per category** whether it is tagged directly
  (`farm_categories`) or through a product in that category — the same "any of"
  rule `?category=` applies on `GET /farms`, so a count always agrees with what
  filtering would return. The subquery uses `UNION`, not `UNION ALL`, so a farm
  tagged both ways isn't double-counted; there's a test for exactly that.
- **Counts are unfiltered on purpose.** They describe the whole directory, so an
  option's count doesn't shift as other filters are applied — which is what makes
  them a stable ordering for a picker. Contextual counts are a different question
  and would take the same filter parameters as `GET /farms`.

Category labels resolve through the same `TaxonomySnapshot` that `GET /taxonomy`
uses, so the two endpoints can't disagree about a name, and the list order
matches.

Cached `public, max-age=300, stale-while-revalidate=3600` — matched to how long
a client caches `GET /farms`. If those lifetimes drift, a visitor sees a count
that disagrees with the list beside it.

### Verification

9 new integration tests covering both tagging paths, the double-tag case, empty
categories, language resolution, the 400 on an unsupported language, the cache
header, and an empty directory.

Full suite green (258 + 113 + 6), `clippy --all-targets -D warnings` clean,
`fmt --check` clean. The `.sqlx` offline cache is regenerated so CI builds
without a database.

README documents the endpoint alongside `GET /taxonomy`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `GET /facets` API endpoint providing farm counts by canton and product category.
  * Includes total farm counts, localized category labels, empty categories, and duplicate-safe counting.
  * Responses use public caching to improve performance for filter selection.

* **Documentation**
  * Documented the `/facets` endpoint, response format, counting rules, and cache behavior in the README.

* **Tests**
  * Added comprehensive coverage for counts, localization, caching, empty directories, and category relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->